### PR TITLE
feat: implement THD+N metric

### DIFF
--- a/src/microstructure_metrics/metrics/__init__.py
+++ b/src/microstructure_metrics/metrics/__init__.py
@@ -1,0 +1,5 @@
+"""Metric implementations."""
+
+from microstructure_metrics.metrics.thd_n import THDNResult, calculate_thd_n
+
+__all__ = ["THDNResult", "calculate_thd_n"]

--- a/src/microstructure_metrics/metrics/thd_n.py
+++ b/src/microstructure_metrics/metrics/thd_n.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import math
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+import numpy.typing as npt
+from scipy.signal.windows import blackmanharris
+
+EPS = 1e-20
+
+
+@dataclass
+class THDNResult:
+    thd_n_db: float
+    thd_n_percent: float
+    thd_db: float
+    noise_db: float
+    fundamental_freq: float
+    fundamental_level_dbfs: float
+    harmonic_levels: dict[int, float]
+    sinad_db: float
+    measurement_bandwidth: tuple[float, float]
+    warnings: list[str]
+
+
+def calculate_thd_n(
+    *,
+    signal: npt.ArrayLike,
+    fundamental_freq: float,
+    sample_rate: int,
+    bandwidth: tuple[float, float] = (20.0, 20000.0),
+    num_harmonics: int = 10,
+    bin_padding: int = 6,
+    search_hz: float | None = None,
+    expected_level_dbfs: float | None = -3.0,
+    gain_tolerance_db: float = 2.0,
+) -> THDNResult:
+    """
+    Calculate THD+N using an FFT-based method.
+
+    The function extracts the fundamental component, aggregates harmonics up to
+    ``num_harmonics``, estimates the residual noise floor within ``bandwidth``,
+    and returns distortion/noise ratios relative to the fundamental.
+    """
+    data = np.asarray(signal, dtype=np.float64)
+    if data.ndim != 1:
+        raise ValueError("signal must be a 1-D array")
+    if data.size == 0:
+        raise ValueError("signal must contain at least one sample")
+    if sample_rate <= 0:
+        raise ValueError("sample_rate must be positive")
+    if fundamental_freq <= 0:
+        raise ValueError("fundamental_freq must be positive")
+    if num_harmonics < 1:
+        raise ValueError("num_harmonics must be >= 1")
+
+    band_low, band_high = bandwidth
+    if band_low < 0 or band_high <= band_low:
+        raise ValueError("bandwidth must be an increasing (low, high) tuple")
+    nyquist = sample_rate / 2
+    band_high = min(band_high, nyquist)
+
+    n_samples = data.shape[0]
+    n_fft = _next_pow_two(n_samples)
+
+    window = blackmanharris(n_samples, sym=False)
+    window_rms = float(np.sqrt(np.mean(np.square(window))))
+    windowed = data * window
+
+    spectrum = np.fft.rfft(windowed, n=n_fft)
+    freqs: npt.NDArray[np.float64] = np.asarray(
+        np.fft.rfftfreq(n_fft, 1.0 / sample_rate), dtype=np.float64
+    )
+    bin_width = freqs[1] - freqs[0] if freqs.shape[0] > 1 else 0.0
+    power_spectrum: npt.NDArray[np.float64] = _weighted_power(spectrum)
+    if not np.isfinite(power_spectrum).all():
+        raise ValueError("spectrum contains non-finite values")
+
+    band_mask = (freqs >= band_low) & (freqs <= band_high)
+    if not np.any(band_mask):
+        raise ValueError("bandwidth does not overlap with the FFT frequency bins")
+
+    band_power = float(power_spectrum[band_mask].sum() / (n_fft**2))
+    if band_power <= 0:
+        raise ValueError("signal has no energy in the specified bandwidth")
+
+    fund_idx = _find_peak_bin(
+        power_spectrum, freqs, target_freq=fundamental_freq, search_hz=search_hz
+    )
+    fund_slice = _bin_slice(fund_idx, padding=bin_padding, length=freqs.shape[0])
+    fundamental_power = float(power_spectrum[fund_slice].sum() / (n_fft**2))
+    if fundamental_power <= 0:
+        raise ValueError("failed to detect fundamental component")
+    fundamental_freq_est = float(
+        np.average(freqs[fund_slice], weights=power_spectrum[fund_slice])
+    )
+
+    exclude_mask = np.zeros_like(freqs, dtype=bool)
+    exclude_mask[fund_slice] = True
+    harmonic_power = 0.0
+    harmonic_powers: dict[int, float] = {}
+    band_high_limit = band_high + bin_width * bin_padding
+    for order in range(2, num_harmonics + 1):
+        harmonic_freq = fundamental_freq_est * order
+        if harmonic_freq > band_high_limit or harmonic_freq >= nyquist:
+            continue
+        try:
+            harmonic_idx = _find_peak_bin(
+                power_spectrum,
+                freqs,
+                target_freq=harmonic_freq,
+                search_hz=search_hz,
+            )
+        except ValueError:
+            continue
+        harmonic_slice = _bin_slice(
+            harmonic_idx, padding=bin_padding, length=freqs.shape[0]
+        )
+        exclude_mask[harmonic_slice] = True
+        hp = float(power_spectrum[harmonic_slice].sum() / (n_fft**2))
+        harmonic_power += hp
+        harmonic_powers[order] = hp
+
+    noise_power = float(power_spectrum[band_mask & ~exclude_mask].sum() / (n_fft**2))
+    dist_noise_power = harmonic_power + noise_power
+
+    fundamental_rms = math.sqrt(max(fundamental_power, EPS))
+    dist_noise_rms = math.sqrt(dist_noise_power)
+    harmonic_rms = math.sqrt(max(harmonic_power, 0.0))
+    noise_rms = math.sqrt(noise_power)
+
+    scale = 1.0 / max(window_rms, EPS)
+    fundamental_rms *= scale
+    dist_noise_rms *= scale
+    harmonic_rms *= scale
+    noise_rms *= scale
+
+    thd_n_ratio = dist_noise_rms / max(fundamental_rms, EPS)
+    thd_ratio = harmonic_rms / max(fundamental_rms, EPS)
+    noise_ratio = noise_rms / max(fundamental_rms, EPS)
+
+    fundamental_peak = fundamental_rms * math.sqrt(2.0)
+    fundamental_level_dbfs = _amplitude_to_dbfs(fundamental_peak)
+
+    harmonic_levels = {
+        order: _amplitude_to_dbfs(math.sqrt(max(power, EPS)) * scale * math.sqrt(2.0))
+        for order, power in harmonic_powers.items()
+    }
+
+    warnings_list: list[str] = []
+    if expected_level_dbfs is not None:
+        deviation = fundamental_level_dbfs - expected_level_dbfs
+        if abs(deviation) > gain_tolerance_db:
+            message = (
+                "Fundamental level deviates from expected "
+                f"({fundamental_level_dbfs:.2f} dBFS vs expected "
+                f"{expected_level_dbfs:+.2f} dBFS)"
+            )
+            warnings.warn(message, stacklevel=2)
+            warnings_list.append(message)
+
+    return THDNResult(
+        thd_n_db=_ratio_to_db(thd_n_ratio),
+        thd_n_percent=thd_n_ratio * 100,
+        thd_db=_ratio_to_db(thd_ratio),
+        noise_db=_ratio_to_db(noise_ratio),
+        fundamental_freq=fundamental_freq_est,
+        fundamental_level_dbfs=fundamental_level_dbfs,
+        harmonic_levels=harmonic_levels,
+        sinad_db=_ratio_to_db(max(fundamental_rms, EPS) / max(dist_noise_rms, EPS)),
+        measurement_bandwidth=(float(band_low), float(band_high)),
+        warnings=warnings_list,
+    )
+
+
+def _next_pow_two(n: int) -> int:
+    return 1 << (max(n - 1, 0).bit_length())
+
+
+def _bin_slice(center: int, *, padding: int, length: int) -> slice:
+    start = max(center - padding, 0)
+    end = min(center + padding + 1, length)
+    return slice(start, end)
+
+
+def _weighted_power(spectrum: npt.NDArray[np.complex128]) -> npt.NDArray[np.float64]:
+    power = np.abs(spectrum) ** 2
+    weights = np.ones_like(power, dtype=np.float64)
+    if power.shape[0] > 1:
+        weights[1:-1] = 2.0
+    return np.asarray(power * weights, dtype=np.float64)
+
+
+def _find_peak_bin(
+    power_spectrum: npt.NDArray[np.float64],
+    freqs: npt.NDArray[np.float64],
+    *,
+    target_freq: float,
+    search_hz: float | None,
+) -> int:
+    bin_width = freqs[1] - freqs[0] if freqs.shape[0] > 1 else 0.0
+    search_radius = search_hz or max(bin_width * 3, target_freq * 0.02)
+    mask = np.abs(freqs - target_freq) <= search_radius
+    if not np.any(mask):
+        raise ValueError(f"no bins near target frequency {target_freq} Hz")
+    local_power = power_spectrum[mask]
+    peak_offset = int(np.argmax(local_power))
+    return int(np.nonzero(mask)[0][peak_offset])
+
+
+def _amplitude_to_dbfs(amplitude: float) -> float:
+    amp = max(amplitude, EPS)
+    return 20.0 * math.log10(amp)
+
+
+def _ratio_to_db(ratio: float) -> float:
+    return 20.0 * math.log10(max(ratio, EPS))

--- a/tests/test_thd_n.py
+++ b/tests/test_thd_n.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from microstructure_metrics.metrics import calculate_thd_n
+
+
+def _tone(
+    freq: float, sample_rate: int, duration: float, *, level_dbfs: float
+) -> np.ndarray:
+    t = np.arange(int(duration * sample_rate)) / sample_rate
+    amplitude = 10 ** (level_dbfs / 20)
+    return amplitude * np.sin(2 * np.pi * freq * t)
+
+
+def test_thd_n_detects_harmonic_and_noise_components() -> None:
+    sr = 48_000
+    duration = 1.0
+    fundamental = _tone(1000.0, sr, duration, level_dbfs=-3.0)
+    harmonic = _tone(
+        2000.0,
+        sr,
+        duration,
+        level_dbfs=-53.0,  # roughly -50 dBc vs -3 dBFS peak
+    )
+    rng = np.random.default_rng(0)
+    noise = rng.normal(0.0, 1e-4, size=fundamental.shape[0])
+    signal = fundamental + harmonic + noise
+
+    result = calculate_thd_n(
+        signal=signal,
+        fundamental_freq=1000.0,
+        sample_rate=sr,
+        num_harmonics=5,
+    )
+
+    assert 995.0 <= result.fundamental_freq <= 1005.0
+    assert -55.0 <= result.thd_db <= -45.0
+    assert -55.0 <= result.thd_n_db <= -45.0
+    assert 2 in result.harmonic_levels
+    assert -60.0 <= result.harmonic_levels[2] <= -40.0
+    assert result.noise_db < -60.0
+
+
+def test_thd_n_respects_bandwidth_and_harmonic_count() -> None:
+    sr = 48_000
+    duration = 0.5
+    fundamental = _tone(4000.0, sr, duration, level_dbfs=-6.0)
+    second = _tone(8000.0, sr, duration, level_dbfs=-40.0)
+    third = _tone(12_000.0, sr, duration, level_dbfs=-45.0)
+    fourth = _tone(16_000.0, sr, duration, level_dbfs=-50.0)  # outside bandwidth
+    signal = fundamental + second + third + fourth
+
+    result = calculate_thd_n(
+        signal=signal,
+        fundamental_freq=4000.0,
+        sample_rate=sr,
+        bandwidth=(20.0, 12_000.0),
+        num_harmonics=6,
+        expected_level_dbfs=None,
+    )
+
+    assert set(result.harmonic_levels.keys()) == {2, 3}
+    assert result.thd_db < -30.0  # harmonics present
+    assert result.measurement_bandwidth == (20.0, 12_000.0)
+
+
+def test_gain_warning_when_fundamental_far_from_expected() -> None:
+    sr = 48_000
+    duration = 0.25
+    signal = _tone(1000.0, sr, duration, level_dbfs=-12.0)
+
+    with pytest.warns(UserWarning):
+        result = calculate_thd_n(
+            signal=signal,
+            fundamental_freq=1000.0,
+            sample_rate=sr,
+            expected_level_dbfs=-3.0,
+            gain_tolerance_db=2.0,
+        )
+
+    assert result.warnings
+    assert "deviates" in result.warnings[0]


### PR DESCRIPTION
## 概要
- THD+N計算モジュールを追加し、基本波・高調波・ノイズをFFTベースで分離してTHD/THD+N/SINADを算出
- 基本波レベル逸脱時の警告を追加
- THD+Nのユニットテストを追加

## テスト
- uv run --extra dev pytest
- uv run --extra dev ruff check src/microstructure_metrics/metrics tests/test_thd_n.py
- uv run --extra dev pre-commit run --all-files

Closes #8