### PR TITLE
fix(report): make --expected-level-dbfs opt-in

### DIFF
--- a/src/microstructure_metrics/cli/report.py
+++ b/src/microstructure_metrics/cli/report.py
@@ -126,9 +126,13 @@ DEFAULT_JSON = "metrics_report.json"
 )
 @click.option(
     "--expected-level-dbfs",
-    default=-3.0,
-    show_default=True,
-    help="THD+N の想定ピークレベル (dBFS)",
+    type=float,
+    default=None,
+    show_default=False,
+    help=(
+        "THD+N の想定ピークレベル (dBFS)。"
+        "指定すると、基本波レベルが許容範囲から外れた場合に警告を出す。"
+    ),
 )
 @click.option(
     "--notch-center-hz",
@@ -234,7 +238,7 @@ def report(
     margin_ms: float,
     max_lag_ms: float,
     fundamental_freq: float,
-    expected_level_dbfs: float,
+    expected_level_dbfs: float | None,
     notch_center_hz: float,
     notch_q: float,
     mps_filterbank: str,
@@ -362,7 +366,7 @@ def _calculate_metrics(
     aligned_dut: Any,
     sample_rate: int,
     fundamental_freq: float,
-    expected_level_dbfs: float,
+    expected_level_dbfs: float | None,
     notch_center_hz: float,
     notch_q: float,
     mps_filterbank: str,


### PR DESCRIPTION
## 目的\n\nreport 実行時に、--expected-level-dbfs を指定していないだけで THD+N のゲイン警告が出る（ノイズになる）ため、デフォルト挙動を整理します。\n\n## 変更内容\n\n- --expected-level-dbfs のデフォルトを None（未指定）に変更\n  - 指定した場合のみ、基本波レベルの逸脱を警告する（従来どおり）\n\n## 動作確認\n\n- uv run pytest\n