### PR TITLE
docs(agents): forbid merge without approval and keep main in root worktree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,5 +89,7 @@ uv run pre-commit run --all-files
 - 作業時はユーザー指示がない限り **worktree** を使用する
 - worktree名は `mm-<ISSUE番号>` （例: `mm-13`）
 - worktree作成時は必ず最新の `origin/main` から分岐する
+- **main固定**: `main` ブランチは **このリポジトリのルート作業ツリー**（例: `/home/.../microstructure-metrics`）でのみチェックアウトする。他のworktreeへ `main` を移動/チェックアウトしてはならない（`fatal: 'main' is already used by worktree ...` の原因になるため）
 - PR作成は GitHub CLI で実行すること（本タスクはAIエージェントが gh コマンドで対応）
 - pre-push フックでは mypy と pytest を必ず実行する
+- **マージ禁止**: ユーザーの明示的な承認（「マージしてよい」等の指示）があるまで、AIエージェントは `gh pr merge` / GitHub UI / 直接push を含む **いかなる手段でもマージしてはならない**（必要な場合は「マージ可否」を質問し、承認待ちで止める）


### PR DESCRIPTION
AIエージェント運用ルールの明文化。\n\n- **マージ禁止**: ユーザーの明示承認があるまでAIエージェントはマージ操作をしない\n- **main固定**:  ブランチはルート作業ツリーでのみチェックアウトし、他worktreeへ移動しない（worktree衝突を防ぐ）\n