### PR TITLE
TFSをSTCC化し統計出力を追加

### DIFF
--- a/docs/en/metrics-interpretation.md
+++ b/docs/en/metrics-interpretation.md
@@ -43,8 +43,8 @@ Purpose: explain how to read the metrics produced by `report` (JSON/CSV/Markdown
 - Heuristic: correlation ≥0.9 good; <0.8 suggests modulation texture degradation. Use `band_correlations` to locate bands.
 
 ### Temporal Fine Structure (TFS)
-- What: high-band phase coherence and group-delay stability. `mean_correlation` (→1 good), `phase_coherence`, `group_delay_std_ms`.
-- Heuristic: correlation ≥0.85 good; `group_delay_std_ms` > ~0.2 ms indicates notable inter-band delay spread. Check `band_group_delays_ms`.
+- What: high-band short-time phase correlation. Check `mean_correlation` (STCC mean), `percentile_05_correlation` (worst-case tail), `correlation_variance`, `phase_coherence`, and `group_delay_std_ms`.
+- Heuristic: `mean_correlation` ≥0.85 is healthy; low `percentile_05_correlation` means intermittent breakdowns. `group_delay_std_ms` > ~0.2 ms indicates noticeable inter-band delay spread. `frame_length_ms`, `frame_hop_ms`, `max_lag_ms`, and `envelope_threshold_db` in the report document the STCC settings (low-envelope frames are dropped).
 
 ### Transient / Edge rounding
 - What: rounded edges in impulses/clicks. Keys: `attack_time_ms` (DUT), `attack_time_delta_ms` (DUT-ref), `edge_sharpness_ratio`, `transient_smearing_index` (width ratio).

--- a/docs/jp/api-cli-reference.md
+++ b/docs/jp/api-cli-reference.md
@@ -70,6 +70,7 @@ uv run microstructure-metrics report ref.wav dut.wav [options]
   - THD: `--fundamental-freq` `--expected-level-dbfs`
   - NPS/ノッチPSD: `--notch-center-hz` `--notch-q`
   - 出力: `--output-json` (default `metrics_report.json`), `--output-csv`, `--output-md`
+  - TFS出力項目: `mean_correlation` / `percentile_05_correlation` / `correlation_variance` に加え、`frame_length_ms` `frame_hop_ms` `max_lag_ms` `envelope_threshold_db`
 - 例: JSON と Markdown を保存
 ```
 uv run microstructure-metrics report ref.aligned_ref.wav dut.aligned_dut.wav \

--- a/docs/jp/metrics-interpretation.md
+++ b/docs/jp/metrics-interpretation.md
@@ -47,9 +47,9 @@
 - 音楽的テクスチャが失われると相関が下がり距離が増える。
 
 ### Temporal Fine Structure (TFS)
-- 内容: 高域微細位相の相関と群遅延のばらつき。`mean_correlation` (1に近いほど良好)、`phase_coherence`、`group_delay_std_ms`。
-- 目安: 相関 0.85 以上で良好。`group_delay_std_ms` が大きい（>0.2 ms 程度）場合、帯域間の時間ずれが大きい可能性。
-- 帯域別 `band_group_delays_ms` で特定の帯域の遅延ズレを確認。
+- 内容: 高域微細位相の短時間相関。`mean_correlation`（STCC平均）、`percentile_05_correlation`（ワースト側分位点）、`correlation_variance`、`phase_coherence`、`group_delay_std_ms` を確認。
+- 目安: `mean_correlation` 0.85 以上で良好。`percentile_05_correlation` が低い場合は一部フレームで崩れている可能性。`group_delay_std_ms` が大きい（>0.2 ms 程度）場合、帯域間の時間ずれが大きい可能性。
+- 帯域別 `band_group_delays_ms` で特定の帯域の遅延ズレを確認。レポートには `frame_length_ms` `frame_hop_ms` `max_lag_ms` `envelope_threshold_db` が記録される（低包絡フレームは除外）。
 
 ### Transient / エッジ丸まり
 - 内容: インパルス/クリックの立ち上がり丸まりを検出。`attack_time_ms`(DUT), `attack_time_delta_ms`(DUT-ref), `edge_sharpness_ratio`, `transient_smearing_index`(幅比) を確認。

--- a/src/microstructure_metrics/cli/report.py
+++ b/src/microstructure_metrics/cli/report.py
@@ -558,10 +558,18 @@ def _tfs_summary(result: TFSCorrelationResult) -> dict[str, object]:
     }
     return {
         "mean_correlation": float(result.mean_correlation),
+        "percentile_05_correlation": float(result.percentile_05_correlation),
+        "correlation_variance": float(result.correlation_variance),
         "phase_coherence": float(result.phase_coherence),
         "group_delay_std_ms": float(result.group_delay_std_ms),
         "band_correlations": band_corr,
         "band_group_delays_ms": group_delays,
+        "frames_per_band": int(result.frames_per_band),
+        "used_frames": int(result.used_frames),
+        "frame_length_ms": float(result.frame_length_ms),
+        "frame_hop_ms": float(result.frame_hop_ms),
+        "max_lag_ms": float(result.max_lag_ms),
+        "envelope_threshold_db": float(result.envelope_threshold_db),
     }
 
 

--- a/src/microstructure_metrics/metrics/tfs.py
+++ b/src/microstructure_metrics/metrics/tfs.py
@@ -1,12 +1,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Literal
 
 import numpy as np
 import numpy.typing as npt
 from scipy import signal as sp_signal
 
 EPS = 1e-12
+DEFAULT_FRAME_LENGTH_MS = 25.0
+DEFAULT_FRAME_HOP_MS = 10.0
+DEFAULT_MAX_LAG_MS = 1.0
+DEFAULT_ENVELOPE_THRESHOLD_DB = -40.0
+DEFAULT_WINDOW: Literal["hann"] = "hann"
 
 
 @dataclass(frozen=True)
@@ -23,10 +29,18 @@ class TFSCorrelationResult:
     """Result of TFS correlation between reference and DUT."""
 
     mean_correlation: float
+    percentile_05_correlation: float
+    correlation_variance: float
     band_correlations: dict[tuple[float, float], float]
     phase_coherence: float
     group_delay_std_ms: float
     band_group_delays_ms: dict[tuple[float, float], float]
+    frame_length_ms: float
+    frame_hop_ms: float
+    max_lag_ms: float
+    envelope_threshold_db: float
+    frames_per_band: int
+    used_frames: int
 
 
 def extract_tfs(
@@ -84,8 +98,13 @@ def calculate_tfs_correlation(
         (6000.0, 8000.0),
     ),
     filter_order: int = 6,
+    frame_length_ms: float = DEFAULT_FRAME_LENGTH_MS,
+    frame_hop_ms: float = DEFAULT_FRAME_HOP_MS,
+    max_lag_ms: float = DEFAULT_MAX_LAG_MS,
+    envelope_threshold_db: float = DEFAULT_ENVELOPE_THRESHOLD_DB,
+    window: Literal["hann"] = DEFAULT_WINDOW,
 ) -> TFSCorrelationResult:
-    """Calculate TFS correlation and phase coherence across bands."""
+    """Calculate short-time TFS correlation and phase coherence across bands."""
 
     ref = np.asarray(reference, dtype=np.float64)
     du = np.asarray(dut, dtype=np.float64)
@@ -99,16 +118,37 @@ def calculate_tfs_correlation(
         raise ValueError("sample_rate must be positive")
     if filter_order < 1:
         raise ValueError("filter_order must be >= 1")
+    if frame_length_ms <= 0 or frame_hop_ms <= 0:
+        raise ValueError("frame_length_ms and frame_hop_ms must be positive")
+    if max_lag_ms < 0:
+        raise ValueError("max_lag_ms must be non-negative")
+    if envelope_threshold_db >= 0:
+        raise ValueError("envelope_threshold_db must be negative (dB relative)")
 
     nyquist = sample_rate / 2
     bands = list(freq_bands)
     if not bands:
         raise ValueError("freq_bands must not be empty")
 
+    frame_length_samples = int(round(frame_length_ms * sample_rate / 1000))
+    hop_samples = int(round(frame_hop_ms * sample_rate / 1000))
+    max_lag_samples = int(round(max_lag_ms * sample_rate / 1000))
+    if frame_length_samples < 1 or hop_samples < 1:
+        raise ValueError("frame_length_ms/hop_ms too small for given sample_rate")
+    if frame_length_samples > ref.size:
+        frame_length_samples = ref.size
+    if frame_length_samples < hop_samples:
+        hop_samples = frame_length_samples
+    frames_per_band = _frame_count(ref.size, frame_length_samples, hop_samples)
+    window_taper = _window(window, frame_length_samples)
+
     band_correlations: dict[tuple[float, float], float] = {}
     band_group_delays_ms: dict[tuple[float, float], float] = {}
     phase_vector_sum = 0.0 + 0.0j
     phase_count = 0
+    all_correlations: list[float] = []
+    all_weights: list[float] = []
+    used_frames = 0
 
     for low, high in bands:
         if low <= 0 or high <= low:
@@ -130,19 +170,43 @@ def calculate_tfs_correlation(
             high=high,
             filter_order=filter_order,
         )
-
-        corr, lag = _normalized_correlation(
-            components_ref.fine_structure, components_dut.fine_structure
+        band_threshold = _envelope_threshold(
+            ref_envelope=components_ref.envelope,
+            dut_envelope=components_dut.envelope,
+            threshold_db=envelope_threshold_db,
         )
+        correlations, lags, weights = _short_time_correlations(
+            ref_fine=components_ref.fine_structure,
+            dut_fine=components_dut.fine_structure,
+            ref_envelope=components_ref.envelope,
+            dut_envelope=components_dut.envelope,
+            window=window_taper,
+            frame_length=frame_length_samples,
+            hop=hop_samples,
+            max_lag=max_lag_samples,
+            envelope_threshold=band_threshold,
+        )
+        used_frames += len(correlations)
         band_key = (float(low), float(high))
-        band_correlations[band_key] = corr
-        band_group_delays_ms[band_key] = (lag / sample_rate) * 1000.0
+        if correlations:
+            band_mean = float(np.average(correlations, weights=weights))
+            band_lag_samples = int(_weighted_median(np.asarray(lags), weights))
+            band_correlations[band_key] = band_mean
+            band_group_delays_ms[band_key] = (band_lag_samples / sample_rate) * 1000.0
+            all_correlations.extend(correlations)
+            all_weights.extend(weights)
+        else:
+            band_correlations[band_key] = 0.0
+            band_group_delays_ms[band_key] = 0.0
+            band_lag_samples = 0
 
-        # Compensate constant time lag (group delay) before phase coherence.
-        # Without this, a benign fixed delay between reference/DUT can artificially
-        # reduce phase coherence even when fine structure matches.
+        # Compensate representative time lag (median of short-time lags) before
+        # phase coherence. This keeps coherence robust to constant offsets while
+        # still reflecting local phase instability.
         phase_ref, phase_dut = _overlap_with_lag(
-            components_ref.instantaneous_phase, components_dut.instantaneous_phase, lag
+            components_ref.instantaneous_phase,
+            components_dut.instantaneous_phase,
+            band_lag_samples,
         )
         if phase_ref.size == 0:
             continue
@@ -151,7 +215,19 @@ def calculate_tfs_correlation(
         phase_vector_sum += np.sum(np.exp(1j * wrapped))
         phase_count += wrapped.size
 
-    mean_correlation = float(np.mean(list(band_correlations.values())))
+    if all_correlations:
+        mean_correlation = float(np.average(all_correlations, weights=all_weights))
+        variance = float(
+            np.average(
+                (np.asarray(all_correlations) - mean_correlation) ** 2,
+                weights=all_weights,
+            )
+        )
+        percentile_05 = float(np.percentile(all_correlations, 5))
+    else:
+        mean_correlation = 0.0
+        variance = 0.0
+        percentile_05 = 0.0
     phase_coherence = (
         float(np.abs(phase_vector_sum) / phase_count) if phase_count > 0 else 0.0
     )
@@ -159,10 +235,18 @@ def calculate_tfs_correlation(
 
     return TFSCorrelationResult(
         mean_correlation=mean_correlation,
+        percentile_05_correlation=percentile_05,
+        correlation_variance=variance,
         band_correlations=band_correlations,
         phase_coherence=phase_coherence,
         group_delay_std_ms=group_delay_std_ms,
         band_group_delays_ms=band_group_delays_ms,
+        frame_length_ms=float(frame_length_samples * 1000 / sample_rate),
+        frame_hop_ms=float(hop_samples * 1000 / sample_rate),
+        max_lag_ms=float(max_lag_samples * 1000 / sample_rate),
+        envelope_threshold_db=float(envelope_threshold_db),
+        frames_per_band=int(frames_per_band),
+        used_frames=int(used_frames),
     )
 
 
@@ -193,7 +277,9 @@ def _bandpass(*, low: float, high: float, sample_rate: int, order: int) -> npt.N
 
 
 def _normalized_correlation(
-    a: npt.NDArray[np.float64], b: npt.NDArray[np.float64]
+    a: npt.NDArray[np.float64],
+    b: npt.NDArray[np.float64],
+    max_lag: int | None = None,
 ) -> tuple[float, int]:
     if a.shape != b.shape:
         raise ValueError("signals must have the same shape for correlation")
@@ -202,6 +288,12 @@ def _normalized_correlation(
         return 0.0, 0
     corr = sp_signal.correlate(a, b, mode="full", method="fft") / denom
     lags = sp_signal.correlation_lags(a.size, b.size, mode="full")
+    if max_lag is not None:
+        window = np.abs(lags) <= max_lag
+        if not np.any(window):
+            return 0.0, 0
+        corr = corr[window]
+        lags = lags[window]
     # Prefer the lag that maximizes *positive* correlation.
     # Using |corr| can pick an inverted (anti-correlated) alignment, which then
     # pollutes downstream stats (including phase coherence).
@@ -239,3 +331,102 @@ def _overlap_with_lag(
     if shift >= a.size:
         return a[:0], b[:0]
     return a[:-shift], b[shift:]
+
+
+def _frame_count(length: int, frame_length: int, hop: int) -> int:
+    if length <= 0:
+        return 0
+    if frame_length <= 0 or hop <= 0:
+        raise ValueError("frame_length and hop must be positive")
+    if length < frame_length:
+        return 1
+    return 1 + (length - frame_length) // hop
+
+
+def _envelope_threshold(
+    *,
+    ref_envelope: npt.NDArray[np.float64],
+    dut_envelope: npt.NDArray[np.float64],
+    threshold_db: float,
+) -> float:
+    peak = max(
+        float(np.max(np.asarray(ref_envelope, dtype=np.float64), initial=0.0)),
+        float(np.max(np.asarray(dut_envelope, dtype=np.float64), initial=0.0)),
+        EPS,
+    )
+    return peak * 10 ** (threshold_db / 20.0)
+
+
+def _window(name: Literal["hann"], length: int) -> npt.NDArray[np.float64]:
+    if length < 1:
+        raise ValueError("window length must be positive")
+    if name == "hann":
+        return np.asarray(np.hanning(length), dtype=np.float64)
+    raise ValueError(f"Unsupported window type: {name}")
+
+
+def _short_time_correlations(
+    *,
+    ref_fine: npt.NDArray[np.float64],
+    dut_fine: npt.NDArray[np.float64],
+    ref_envelope: npt.NDArray[np.float64],
+    dut_envelope: npt.NDArray[np.float64],
+    window: npt.NDArray[np.float64],
+    frame_length: int,
+    hop: int,
+    max_lag: int,
+    envelope_threshold: float,
+) -> tuple[list[float], list[int], list[float]]:
+    if (
+        ref_fine.shape != dut_fine.shape
+        or ref_envelope.shape != dut_envelope.shape
+        or ref_fine.shape != ref_envelope.shape
+    ):
+        raise ValueError("ref/dut fine structures and envelopes must share shape")
+    correlations: list[float] = []
+    lags: list[int] = []
+    weights: list[float] = []
+    if frame_length < 1 or hop < 1:
+        return correlations, lags, weights
+
+    signal_length = ref_fine.size
+    if signal_length < frame_length:
+        frame_length = signal_length
+    if frame_length == 0:
+        return correlations, lags, weights
+
+    for start in range(0, signal_length - frame_length + 1, hop):
+        stop = start + frame_length
+        env_mean = float(
+            np.mean(
+                0.5 * (ref_envelope[start:stop] + dut_envelope[start:stop]),
+                dtype=np.float64,
+            )
+        )
+        if env_mean <= envelope_threshold:
+            continue
+        ref_frame = ref_fine[start:stop] * window
+        dut_frame = dut_fine[start:stop] * window
+        corr, lag = _normalized_correlation(ref_frame, dut_frame, max_lag)
+        correlations.append(corr)
+        lags.append(lag)
+        weights.append(env_mean)
+
+    return correlations, lags, weights
+
+
+def _weighted_median(values: npt.NDArray[np.float64], weights: list[float]) -> float:
+    if values.size == 0:
+        return 0.0
+    weights_array = np.asarray(weights, dtype=np.float64)
+    if weights_array.size != values.size:
+        raise ValueError("values and weights must have the same length")
+    if np.all(weights_array == 0):
+        return float(np.median(values))
+    order = np.argsort(values)
+    sorted_vals = values[order]
+    sorted_weights = weights_array[order]
+    cumulative = np.cumsum(sorted_weights)
+    cutoff = 0.5 * cumulative[-1]
+    idx = int(np.searchsorted(cumulative, cutoff))
+    return float(sorted_vals[min(idx, sorted_vals.size - 1)])

--- a/src/microstructure_metrics/testing/__init__.py
+++ b/src/microstructure_metrics/testing/__init__.py
@@ -55,6 +55,8 @@ _ALL_METRIC_KEYS = {
     "psd_dut_notch_depth_db",
     "tfs_mean_correlation",
     "tfs_phase_coherence",
+    "tfs_percentile_05_correlation",
+    "tfs_correlation_variance",
     "attack_time_ms",
     "attack_time_delta_ms",
     "edge_sharpness_ratio",
@@ -123,6 +125,8 @@ DEFAULT_REGRESSION_CASES: tuple[RegressionCase, ...] = (
             "mps_distance",
             "tfs_mean_correlation",
             "tfs_phase_coherence",
+            "tfs_percentile_05_correlation",
+            "tfs_correlation_variance",
         ),
     ),
     RegressionCase(
@@ -235,7 +239,12 @@ DEFAULT_REGRESSION_CASES: tuple[RegressionCase, ...] = (
         severity=0.75,
         duration=1.0,
         description="slow phase warp via all-pass style modulation.",
-        metrics=("tfs_mean_correlation", "tfs_phase_coherence"),
+        metrics=(
+            "tfs_mean_correlation",
+            "tfs_phase_coherence",
+            "tfs_percentile_05_correlation",
+            "tfs_correlation_variance",
+        ),
     ),
     RegressionCase(
         key="modulation_suppression",
@@ -761,12 +770,19 @@ def evaluate_metrics(
         results["mps_distance"] = mps.mps_distance
         results["mps_distance_weighted"] = mps.mps_distance_weighted
 
-    if {"tfs_mean_correlation", "tfs_phase_coherence"} & requested:
+    if {
+        "tfs_mean_correlation",
+        "tfs_phase_coherence",
+        "tfs_percentile_05_correlation",
+        "tfs_correlation_variance",
+    } & requested:
         tfs = calculate_tfs_correlation(
             reference=reference, dut=dut, sample_rate=sample_rate
         )
         results["tfs_mean_correlation"] = tfs.mean_correlation
         results["tfs_phase_coherence"] = tfs.phase_coherence
+        results["tfs_percentile_05_correlation"] = tfs.percentile_05_correlation
+        results["tfs_correlation_variance"] = tfs.correlation_variance
 
     if {
         "attack_time_ms",

--- a/tests/expected_values.yaml
+++ b/tests/expected_values.yaml
@@ -9,11 +9,17 @@ band_limit:
       expected: 0.0014395500504565618
       tolerance: 0.01
     tfs_mean_correlation:
-      expected: 0.9438451903855913
+      expected: 0.9501937876988462
       tolerance: 0.05
     tfs_phase_coherence:
-      expected: 0.94644920262413
+      expected: 0.9342608030088518
       tolerance: 0.05
+    tfs_percentile_05_correlation:
+      expected: 0.9373920351791751
+      tolerance: 0.05
+    tfs_correlation_variance:
+      expected: 0.000350837485298738
+      tolerance: 0.01
   severity: 0.8
   signal_type: tfs-tones
 edge_rounding_click:
@@ -210,11 +216,17 @@ phase_distortion:
   description: slow phase warp via all-pass style modulation.
   metrics:
     tfs_mean_correlation:
-      expected: 0.9396838519319823
+      expected: 0.9531274833525679
       tolerance: 0.05
     tfs_phase_coherence:
-      expected: 0.9297140544040522
+      expected: 0.656407188768625
+      tolerance: 0.1
+    tfs_percentile_05_correlation:
+      expected: 0.8946363407794006
       tolerance: 0.05
+    tfs_correlation_variance:
+      expected: 0.0012137311656648076
+      tolerance: 0.01
   severity: 0.75
   signal_type: tfs-tones
 soft_clipping:

--- a/tests/test_cli_report.py
+++ b/tests/test_cli_report.py
@@ -55,6 +55,18 @@ def test_cli_report_outputs_json_csv_md(tmp_path: Path) -> None:
     payload = json.loads(json_path.read_text())
     for key in ["thd_n", "nps", "notch_psd", "delta_se", "transient", "mps", "tfs"]:
         assert key in payload["metrics"]
+    tfs_payload = payload["metrics"]["tfs"]
+    for key in [
+        "percentile_05_correlation",
+        "correlation_variance",
+        "frames_per_band",
+        "frame_length_ms",
+        "frame_hop_ms",
+        "max_lag_ms",
+        "envelope_threshold_db",
+    ]:
+        assert key in tfs_payload
+    assert tfs_payload["frames_per_band"] > 0
     assert abs(payload["alignment"]["delay_samples"] - delay_samples) < 10
 
     assert csv_path.exists()


### PR DESCRIPTION
## Summary
- TFS計算を短時間相互相関(STCC)ベースにし、5%分位点や分散を出力
- 低包絡フレームの除外とフレーム長/ホップ/最大ラグ等のパラメータをレポートに記録
- 期待値・CLI出力・ドキュメントを更新

## Testing
- uv run pytest tests/test_tfs.py tests/test_cli_report.py tests/test_regression.py
- uv run ruff check src/microstructure_metrics/metrics/tfs.py src/microstructure_metrics/cli/report.py src/microstructure_metrics/testing/__init__.py tests/test_tfs.py tests/test_cli_report.py
- uv run mypy src/microstructure_metrics/metrics/tfs.py src/microstructure_metrics/cli/report.py src/microstructure_metrics/testing/__init__.py

Closes #55