### PR TITLE
[S-66] Binaural cue preservation metrics

### DIFF
--- a/docs/jp/api-cli-reference.md
+++ b/docs/jp/api-cli-reference.md
@@ -64,7 +64,7 @@ uv run microstructure-metrics report ref.wav dut.wav [options]
 ```
 - 主なオプション:
   - 入力処理: `--allow-resample` `--target-sample-rate` `--channels`
-    - `--channels`: `stereo|mid|side` を選択。I/Oは常に2chへ正規化され、mid/sideは2chへ写像して解析する。
+    - `--channels`: `stereo|mid|side|ch0|ch1` を選択。I/Oは常に2chへ正規化され、mid/sideは2chへ写像、ch0/ch1は指定chを複製して解析する。
   - アライメント: `--align/--no-align` `--pilot-freq` `--pilot-threshold`
     `--pilot-band-width-hz` `--pilot-duration-ms` `--min-duration-ms`
     `--margin-ms` `--max-lag-ms`
@@ -72,6 +72,7 @@ uv run microstructure-metrics report ref.wav dut.wav [options]
   - 出力: `--output-json` (default `metrics_report.json`), `--output-csv`, `--output-md`
   - 可視化: `--plot` (MPS差分ヒートマップ / TFS相関時系列を保存), `--plot-dir` (プロット出力先ディレクトリ)
   - TFS出力項目: `mean_correlation` / `percentile_05_correlation` / `correlation_variance` に加え、`frame_length_ms` `frame_hop_ms` `max_lag_ms` `envelope_threshold_db`
+  - Binaural出力項目: `median_abs_delta_itd_ms` / `p95_abs_delta_itd_ms` / `itd_outlier_rate` / `median_abs_delta_ild_db` / `p95_abs_delta_ild_db` / `iacc_p05` など
 - 例: JSON と Markdown を保存
 ```
 uv run microstructure-metrics report ref.aligned_ref.wav dut.aligned_dut.wav \

--- a/docs/jp/metrics-interpretation.md
+++ b/docs/jp/metrics-interpretation.md
@@ -40,6 +40,12 @@
 - 入力条件: 単一インパルスや急峻ステップなどエッジを含む刺激（`signal-specifications.md`参照）。定常ノイズやサイン波では意味を持たない。
 - ノイズ/位相ばらつき耐性: 包絡エネルギーを平滑してから特徴抽出。イベント数が0の場合は指標は0となる。
 
+### Binaural Cue Preservation (BCP)
+- 内容: 帯域×時間で ITD/ILD/IACC を推定し、参照との差分を分位点で集約。像の揺れ・広がりを捉える。
+- 主指標: `median_abs_delta_itd_ms`, `p95_abs_delta_itd_ms`, `itd_outlier_rate`(>|0.2|ms率)、`median_abs_delta_ild_db`, `p95_abs_delta_ild_db`, `iacc_p05`, `delta_iacc_median`。
+- 目安: `median_abs_delta_itd_ms` が 0.2 ms 未満なら定位はほぼ安定。`itd_outlier_rate` が高いと瞬間的な定位崩れを疑う。`iacc_p05` が 0.7 未満なら像の締まり低下の可能性。
+- 入力条件: ステレオ信号必須。低包絡フレームは除外されるため、十分なSNRが必要。
+
 ## 典型的な読み解き例
 - 「MPS 相関 0.75, 距離大、TFS 相関 0.8」: テクスチャと位相微細構造がともに崩れており、フィードバックや帯域制限の影響が考えられる。
 - 「THD+N/SINAD 良好だが MPS/TFS が劣化」: 定常指標では見えない微細構造の劣化。駆動系やフィルタ設定を再確認。

--- a/src/microstructure_metrics/metrics/__init__.py
+++ b/src/microstructure_metrics/metrics/__init__.py
@@ -1,5 +1,10 @@
 """Metric implementations."""
 
+from microstructure_metrics.metrics.binaural import (
+    BinauralBandStats,
+    BinauralResult,
+    calculate_binaural_cue_preservation,
+)
 from microstructure_metrics.metrics.mps import (
     MPSResult,
     MPSSimilarityResult,
@@ -28,6 +33,9 @@ __all__ = [
     "MPSSimilarityResult",
     "calculate_mps",
     "calculate_mps_similarity",
+    "BinauralBandStats",
+    "BinauralResult",
+    "calculate_binaural_cue_preservation",
     "TFSComponents",
     "TFSCorrelationResult",
     "extract_tfs",

--- a/src/microstructure_metrics/metrics/binaural.py
+++ b/src/microstructure_metrics/metrics/binaural.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal, cast
+
+import numpy as np
+import numpy.typing as npt
+from scipy import signal as sp_signal
+
+from microstructure_metrics.filterbank import GammatoneFilterbank, MelFilterbank
+
+EPS = 1e-12
+
+
+@dataclass(frozen=True)
+class BinauralBandStats:
+    """帯域ごとの集約値。"""
+
+    center_freq_hz: float
+    median_abs_delta_itd_ms: float
+    median_abs_delta_ild_db: float
+    median_iacc: float
+
+
+@dataclass(frozen=True)
+class BinauralResult:
+    """BCP（Binaural Cue Preservation）計算結果。"""
+
+    median_abs_delta_itd_ms: float
+    p95_abs_delta_itd_ms: float
+    itd_outlier_rate: float
+    median_abs_delta_ild_db: float
+    p95_abs_delta_ild_db: float
+    iacc_p05: float
+    delta_iacc_median: float
+    band_stats: tuple[BinauralBandStats, ...]
+    frame_times_ms: npt.NDArray[np.float64]
+    itd_ref_ms: npt.NDArray[np.float64]
+    itd_dut_ms: npt.NDArray[np.float64]
+    ild_ref_db: npt.NDArray[np.float64]
+    ild_dut_db: npt.NDArray[np.float64]
+    iacc_ref: npt.NDArray[np.float64]
+    iacc_dut: npt.NDArray[np.float64]
+    weights: npt.NDArray[np.float64]
+    frame_length_ms: float
+    frame_hop_ms: float
+    max_itd_ms: float
+    envelope_threshold_db: float
+    itd_outlier_threshold_ms: float
+    freq_centers_hz: npt.NDArray[np.float64]
+    frames_per_band: int
+    used_frames: int
+
+
+@dataclass(frozen=True)
+class BinauralSummary:
+    """Binaural集約値。"""
+
+    median_abs_delta_itd_ms: float
+    p95_abs_delta_itd_ms: float
+    itd_outlier_rate: float
+    median_abs_delta_ild_db: float
+    p95_abs_delta_ild_db: float
+    iacc_p05: float
+    delta_iacc_median: float
+    band_stats: tuple[BinauralBandStats, ...]
+
+
+def calculate_binaural_cue_preservation(
+    *,
+    reference_lr: npt.ArrayLike,
+    dut_lr: npt.ArrayLike,
+    sample_rate: int,
+    audio_freq_range: tuple[float, float] = (125.0, 8000.0),
+    num_audio_bands: int = 16,
+    frame_length_ms: float = 25.0,
+    frame_hop_ms: float = 10.0,
+    max_itd_ms: float = 1.0,
+    envelope_threshold_db: float = -50.0,
+    itd_outlier_threshold_ms: float = 0.2,
+    filterbank: Literal["gammatone", "mel"] = "gammatone",
+    filterbank_kwargs: Mapping[str, float | int | None] | None = None,
+) -> BinauralResult:
+    """左右手がかり(ITD/ILD/IACC)の保存度を計算する。
+
+    Args:
+        reference_lr: 参照ステレオ信号 (samples, 2)。
+        dut_lr: DUTステレオ信号 (samples, 2)。
+        sample_rate: サンプルレート(Hz)。
+        audio_freq_range: 分析帯域の下限・上限(Hz)。
+        num_audio_bands: 聴覚フィルタの本数。
+        frame_length_ms: 短時間解析フレーム長(ms)。
+        frame_hop_ms: フレームシフト(ms)。
+        max_itd_ms: ITD探索の最大ラグ(ms)。
+        envelope_threshold_db: フレーム無視の包絡閾値(dBFS相対)。
+        itd_outlier_threshold_ms: ITD外れ値判定閾値(ms)。
+        filterbank: 聴覚フィルタ種類。
+        filterbank_kwargs: フィルタバンク固有パラメータ。
+    """
+    ref = np.asarray(reference_lr, dtype=np.float64)
+    dut = np.asarray(dut_lr, dtype=np.float64)
+    if ref.ndim != 2 or dut.ndim != 2:
+        raise ValueError("reference_lr/dut_lr must be 2-D (samples, channels).")
+    if ref.shape != dut.shape:
+        raise ValueError("reference_lr and dut_lr must share the same shape.")
+    if ref.shape[1] != 2:
+        raise ValueError("Stereo signals with 2 channels are required.")
+    if sample_rate <= 0:
+        raise ValueError("sample_rate must be positive.")
+    if frame_length_ms <= 0 or frame_hop_ms <= 0:
+        raise ValueError("frame_length_ms and frame_hop_ms must be positive.")
+    audio_low, audio_high = audio_freq_range
+    if audio_low <= 0 or audio_high <= audio_low:
+        raise ValueError("audio_freq_range must be an increasing (low, high) tuple.")
+
+    fb_kwargs = dict(filterbank_kwargs or {})
+    nyquist = sample_rate / 2
+    high_limit = min(audio_high, nyquist * 0.99)
+    width_value = fb_kwargs.get("width")
+    width = float(width_value) if width_value is not None else 1.0
+    order_value = fb_kwargs.get("order")
+    bandwidth_value = fb_kwargs.get("bandwidth_scale")
+    order = int(order_value) if order_value is not None else 4
+    bandwidth_scale = float(bandwidth_value) if bandwidth_value is not None else 1.0
+    if filterbank == "gammatone":
+        fb: GammatoneFilterbank | MelFilterbank = GammatoneFilterbank(
+            sample_rate=sample_rate,
+            num_filters=num_audio_bands,
+            low_freq=audio_low,
+            high_freq=high_limit,
+            width=width,
+        )
+    else:
+        fb = MelFilterbank(
+            sample_rate=sample_rate,
+            num_filters=num_audio_bands,
+            low_freq=audio_low,
+            high_freq=high_limit,
+            order=order,
+            bandwidth_scale=bandwidth_scale,
+        )
+
+    ref_left = fb.analyze(ref[:, 0])
+    ref_right = fb.analyze(ref[:, 1])
+    dut_left = fb.analyze(dut[:, 0])
+    dut_right = fb.analyze(dut[:, 1])
+
+    frame_length = int(round(frame_length_ms * sample_rate / 1000))
+    frame_hop = int(round(frame_hop_ms * sample_rate / 1000))
+    max_lag_samples = int(round(max_itd_ms * sample_rate / 1000))
+    if frame_length < 2:
+        raise ValueError("frame_length_ms is too small for the given sample_rate.")
+    if frame_hop < 1:
+        frame_hop = 1
+    frame_starts = list(range(0, ref.shape[0] - frame_length + 1, frame_hop))
+    frames_per_band = len(frame_starts)
+    frame_times_ms = np.asarray(
+        [(start + frame_length / 2) * 1000 / sample_rate for start in frame_starts],
+        dtype=np.float64,
+    )
+
+    shape = (num_audio_bands, frames_per_band)
+    itd_ref_ms = np.full(shape, np.nan, dtype=np.float64)
+    itd_dut_ms = np.full(shape, np.nan, dtype=np.float64)
+    ild_ref_db = np.full(shape, np.nan, dtype=np.float64)
+    ild_dut_db = np.full(shape, np.nan, dtype=np.float64)
+    iacc_ref = np.full(shape, np.nan, dtype=np.float64)
+    iacc_dut = np.full(shape, np.nan, dtype=np.float64)
+    weights = np.zeros(shape, dtype=np.float64)
+
+    global_peak = float(
+        max(np.max(np.abs(ref), initial=0.0), np.max(np.abs(dut), initial=0.0), EPS)
+    )
+    envelope_threshold = global_peak * 10 ** (envelope_threshold_db / 20.0)
+
+    for band_idx in range(num_audio_bands):
+        ref_l_band = ref_left[band_idx]
+        ref_r_band = ref_right[band_idx]
+        dut_l_band = dut_left[band_idx]
+        dut_r_band = dut_right[band_idx]
+        for frame_idx, start in enumerate(frame_starts):
+            stop = start + frame_length
+            ref_l_frame = ref_l_band[start:stop]
+            ref_r_frame = ref_r_band[start:stop]
+            dut_l_frame = dut_l_band[start:stop]
+            dut_r_frame = dut_r_band[start:stop]
+
+            rms_val = _joint_rms(ref_l_frame, ref_r_frame, dut_l_frame, dut_r_frame)
+            if rms_val <= envelope_threshold:
+                continue
+
+            ild_ref_db[band_idx, frame_idx] = _ild_db(ref_l_frame, ref_r_frame)
+            ild_dut_db[band_idx, frame_idx] = _ild_db(dut_l_frame, dut_r_frame)
+
+            itd_ref, iacc_ref_val = _lag_and_iacc(
+                ref_l_frame, ref_r_frame, max_lag_samples, sample_rate
+            )
+            itd_dut_val, iacc_dut_val = _lag_and_iacc(
+                dut_l_frame, dut_r_frame, max_lag_samples, sample_rate
+            )
+            itd_ref_ms[band_idx, frame_idx] = itd_ref
+            itd_dut_ms[band_idx, frame_idx] = itd_dut_val
+            iacc_ref[band_idx, frame_idx] = iacc_ref_val
+            iacc_dut[band_idx, frame_idx] = iacc_dut_val
+            weights[band_idx, frame_idx] = rms_val
+
+    summary = _summarize(
+        itd_ref_ms=itd_ref_ms,
+        itd_dut_ms=itd_dut_ms,
+        ild_ref_db=ild_ref_db,
+        ild_dut_db=ild_dut_db,
+        iacc_ref=iacc_ref,
+        iacc_dut=iacc_dut,
+        weights=weights,
+        freq_centers=np.asarray(fb.center_frequencies, dtype=np.float64),
+        itd_outlier_threshold_ms=itd_outlier_threshold_ms,
+    )
+
+    return BinauralResult(
+        median_abs_delta_itd_ms=summary.median_abs_delta_itd_ms,
+        p95_abs_delta_itd_ms=summary.p95_abs_delta_itd_ms,
+        itd_outlier_rate=summary.itd_outlier_rate,
+        median_abs_delta_ild_db=summary.median_abs_delta_ild_db,
+        p95_abs_delta_ild_db=summary.p95_abs_delta_ild_db,
+        iacc_p05=summary.iacc_p05,
+        delta_iacc_median=summary.delta_iacc_median,
+        band_stats=summary.band_stats,
+        frame_times_ms=frame_times_ms,
+        itd_ref_ms=itd_ref_ms,
+        itd_dut_ms=itd_dut_ms,
+        ild_ref_db=ild_ref_db,
+        ild_dut_db=ild_dut_db,
+        iacc_ref=iacc_ref,
+        iacc_dut=iacc_dut,
+        weights=weights,
+        frame_length_ms=float(frame_length_ms),
+        frame_hop_ms=float(frame_hop_ms),
+        max_itd_ms=float(max_itd_ms),
+        envelope_threshold_db=float(envelope_threshold_db),
+        itd_outlier_threshold_ms=float(itd_outlier_threshold_ms),
+        freq_centers_hz=np.asarray(fb.center_frequencies, dtype=np.float64),
+        frames_per_band=int(frames_per_band),
+        used_frames=int(np.count_nonzero(weights > 0)),
+    )
+
+
+def _lag_and_iacc(
+    left: npt.NDArray[np.float64],
+    right: npt.NDArray[np.float64],
+    max_lag_samples: int,
+    sample_rate: int,
+) -> tuple[float, float]:
+    if left.shape != right.shape:
+        raise ValueError("Left/right frames must share shape.")
+
+    denom = float(np.linalg.norm(left) * np.linalg.norm(right))
+    if denom <= 0:
+        return 0.0, 0.0
+    corr = sp_signal.correlate(left, right, mode="full", method="fft") / denom
+    lags = sp_signal.correlation_lags(left.size, right.size, mode="full")
+    if max_lag_samples >= 0:
+        window = np.abs(lags) <= max_lag_samples
+        if not np.any(window):
+            return 0.0, 0.0
+        corr = corr[window]
+        lags = lags[window]
+    idx = int(np.argmax(np.abs(corr)))
+    lag_samples = int(lags[idx])
+    itd_ms = (lag_samples / sample_rate) * 1000.0
+    return float(itd_ms), float(np.abs(np.clip(corr[idx], -1.0, 1.0)))
+
+
+def _ild_db(left: npt.NDArray[np.float64], right: npt.NDArray[np.float64]) -> float:
+    rms_left = float(np.sqrt(np.mean(np.square(left), dtype=np.float64)))
+    rms_right = float(np.sqrt(np.mean(np.square(right), dtype=np.float64)))
+    if rms_right <= 0 and rms_left <= 0:
+        return 0.0
+    ratio = max(rms_left, EPS) / max(rms_right, EPS)
+    return float(20.0 * np.log10(ratio))
+
+
+def _joint_rms(*frames: npt.NDArray[np.float64]) -> float:
+    components = [f.ravel() for f in frames if f.size]
+    if not components:
+        return 0.0
+    stacked = np.hstack(components)
+    return float(np.sqrt(np.mean(np.square(stacked), dtype=np.float64)))
+
+
+def _weighted_percentile(
+    values: npt.NDArray[np.float64],
+    weights: npt.NDArray[np.float64],
+    percentile: float,
+) -> float:
+    if values.size == 0 or weights.size == 0:
+        return 0.0
+    valid = np.isfinite(values) & np.isfinite(weights) & (weights > 0)
+    if not np.any(valid):
+        return 0.0
+    vals = cast(npt.NDArray[np.float64], np.asarray(values[valid], dtype=np.float64))
+    w = cast(npt.NDArray[np.float64], np.asarray(weights[valid], dtype=np.float64))
+    order = np.argsort(vals)
+    vals_sorted = vals[order]
+    w_sorted = w[order]
+    cumulative = np.cumsum(w_sorted)
+    cutoff = percentile * cumulative[-1]
+    idx = int(np.searchsorted(cumulative, cutoff))
+    idx = min(idx, vals_sorted.size - 1)
+    value_array = np.asarray(vals_sorted[idx], dtype=np.float64)
+    value = float(value_array.item())
+    return value
+
+
+def _summarize(
+    *,
+    itd_ref_ms: npt.NDArray[np.float64],
+    itd_dut_ms: npt.NDArray[np.float64],
+    ild_ref_db: npt.NDArray[np.float64],
+    ild_dut_db: npt.NDArray[np.float64],
+    iacc_ref: npt.NDArray[np.float64],
+    iacc_dut: npt.NDArray[np.float64],
+    weights: npt.NDArray[np.float64],
+    freq_centers: npt.NDArray[np.float64],
+    itd_outlier_threshold_ms: float,
+) -> BinauralSummary:
+    delta_itd = itd_dut_ms - itd_ref_ms
+    delta_ild = ild_dut_db - ild_ref_db
+    delta_iacc = iacc_dut - iacc_ref
+
+    abs_delta_itd = np.abs(delta_itd)
+    abs_delta_ild = np.abs(delta_ild)
+    valid_weights = np.where(np.isfinite(weights), weights, 0.0)
+
+    median_abs_delta_itd_ms = _weighted_percentile(abs_delta_itd, valid_weights, 0.5)
+    p95_abs_delta_itd_ms = _weighted_percentile(abs_delta_itd, valid_weights, 0.95)
+    median_abs_delta_ild_db = _weighted_percentile(abs_delta_ild, valid_weights, 0.5)
+    p95_abs_delta_ild_db = _weighted_percentile(abs_delta_ild, valid_weights, 0.95)
+    delta_iacc_median = _weighted_percentile(delta_iacc, valid_weights, 0.5)
+    iacc_p05 = _weighted_percentile(iacc_dut, valid_weights, 0.05)
+
+    outlier_mask = abs_delta_itd > itd_outlier_threshold_ms
+    weighted_outliers = float(np.sum(valid_weights[outlier_mask]))
+    weight_total = float(np.sum(valid_weights))
+    itd_outlier_rate = weighted_outliers / weight_total if weight_total > 0 else 0.0
+
+    band_stats: list[BinauralBandStats] = []
+    for idx, center in enumerate(freq_centers):
+        band_weights = valid_weights[idx]
+        band_median_itd = _weighted_percentile(abs_delta_itd[idx], band_weights, 0.5)
+        band_median_ild = _weighted_percentile(abs_delta_ild[idx], band_weights, 0.5)
+        band_median_iacc = _weighted_percentile(iacc_dut[idx], band_weights, 0.5)
+        band_stats.append(
+            BinauralBandStats(
+                center_freq_hz=float(center),
+                median_abs_delta_itd_ms=band_median_itd,
+                median_abs_delta_ild_db=band_median_ild,
+                median_iacc=band_median_iacc,
+            )
+        )
+
+    return BinauralSummary(
+        median_abs_delta_itd_ms=float(median_abs_delta_itd_ms),
+        p95_abs_delta_itd_ms=float(p95_abs_delta_itd_ms),
+        itd_outlier_rate=float(itd_outlier_rate),
+        median_abs_delta_ild_db=float(median_abs_delta_ild_db),
+        p95_abs_delta_ild_db=float(p95_abs_delta_ild_db),
+        iacc_p05=float(iacc_p05),
+        delta_iacc_median=float(delta_iacc_median),
+        band_stats=tuple(band_stats),
+    )

--- a/tests/test_binaural.py
+++ b/tests/test_binaural.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from microstructure_metrics.metrics import calculate_binaural_cue_preservation
+
+
+def test_binaural_cue_preservation_recovers_itd_and_ild() -> None:
+    sample_rate = 48_000
+    duration = 0.3
+    itd_samples = 10  # ≈0.208 ms
+    ild_db = 1.5
+
+    t = np.arange(int(duration * sample_rate)) / sample_rate
+    base = 0.7 * np.sin(2 * np.pi * 500 * t) + 0.3 * np.sin(2 * np.pi * 1500 * t)
+    right_shifted = np.concatenate([np.zeros(itd_samples), base])[: base.size]
+    scale = 10 ** (-ild_db / 20)
+
+    reference = np.stack([base, base], axis=1)
+    dut = np.stack([base, right_shifted * scale], axis=1)
+
+    result = calculate_binaural_cue_preservation(
+        reference_lr=reference,
+        dut_lr=dut,
+        sample_rate=sample_rate,
+        num_audio_bands=8,
+        frame_length_ms=30.0,
+        frame_hop_ms=15.0,
+        max_itd_ms=1.0,
+        envelope_threshold_db=-60.0,
+        itd_outlier_threshold_ms=0.25,
+    )
+
+    expected_itd_ms = itd_samples / sample_rate * 1000.0
+    assert result.used_frames > 0
+    assert result.median_abs_delta_itd_ms == pytest.approx(
+        expected_itd_ms, rel=0.2, abs=0.08
+    )
+    assert result.median_abs_delta_ild_db == pytest.approx(ild_db, rel=0.2, abs=0.4)
+    assert result.itd_outlier_rate < 0.2
+    assert result.iacc_p05 > 0.6
+    assert result.band_stats

--- a/tests/test_cli_report.py
+++ b/tests/test_cli_report.py
@@ -75,7 +75,10 @@ def test_cli_report_outputs_json_csv_md(tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert json_path.exists()
     payload = json.loads(json_path.read_text())
-    assert set(payload["metrics"].keys()) == {"ch0", "ch1"}
+    assert set(payload["metrics"].keys()) == {"ch0", "ch1", "binaural"}
+    binaural = payload["metrics"]["binaural"]
+    assert "summary" in binaural
+    assert "median_abs_delta_itd_ms" in binaural["summary"]
     ch0 = payload["metrics"]["ch0"]
     for key in ["thd_n", "transient", "mps", "tfs"]:
         assert key in ch0
@@ -144,7 +147,7 @@ def test_cli_report_channels_stereo(tmp_path: Path) -> None:
 
     assert result.exit_code == 0, result.output
     payload = json.loads(json_path.read_text())
-    assert set(payload["metrics"].keys()) == {"ch0", "ch1"}
+    assert set(payload["metrics"].keys()) == {"ch0", "ch1", "binaural"}
     for channel_key in ["ch0", "ch1"]:
         ch_metrics = payload["metrics"][channel_key]
         for key in ["thd_n", "transient", "mps", "tfs"]:
@@ -184,6 +187,7 @@ def test_cli_report_no_align_with_resample(tmp_path: Path) -> None:
     # no-align でも metrics が生成され、alignment は delay 0 のダミー
     assert payload["alignment"]["delay_samples"] == 0.0
     assert payload["metrics"]["ch0"]["thd_n"]
+    assert "binaural" in payload["metrics"]
 
 
 def test_cli_report_fails_without_resample_permission(tmp_path: Path) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -169,6 +169,32 @@ def test_channels_option_stereo_mid_side(tmp_path: Path) -> None:
     assert np.allclose(ref_side[:, 1], -expected_side, atol=1e-12)
 
 
+def test_channels_option_ch0_ch1(tmp_path: Path) -> None:
+    sr = 48_000
+    duration = 0.08
+    left = _sine(duration, sr, amplitude=0.3)
+    right = np.full_like(left, 0.1)
+    stereo = np.stack([left, right], axis=1)
+    ref_path = tmp_path / "ref.wav"
+    dut_path = tmp_path / "dut.wav"
+    sf.write(ref_path, stereo, sr, subtype="PCM_24")
+    sf.write(dut_path, stereo, sr, subtype="PCM_24")
+
+    ref_ch0, _, validation0 = load_audio_pair(
+        ref_path, dut_path, channels="ch0", remove_dc=False
+    )
+    assert np.allclose(ref_ch0[:, 0], left, atol=1e-12)
+    assert np.allclose(ref_ch0[:, 1], left, atol=1e-12)
+    assert any("selected channel 0" in w for w in validation0.warnings)
+
+    ref_ch1, _, validation1 = load_audio_pair(
+        ref_path, dut_path, channels="ch1", remove_dc=False
+    )
+    assert np.allclose(ref_ch1[:, 0], right, atol=1e-12)
+    assert np.allclose(ref_ch1[:, 1], right, atol=1e-12)
+    assert any("selected channel 1" in w for w in validation1.warnings)
+
+
 def test_normalize_peak_and_rms(tmp_path: Path) -> None:
     sr = 48_000
     dur = 0.1


### PR DESCRIPTION
## Summary
- add binaural cue preservation metric with ITD/ILD/IACC stats and band summaries
- extend report CLI to output metrics.binaural and broaden --channels options
- document BCP usage and add regression tests for IO, CLI, and metric core

## Testing
- uv run ruff check src tests
- uv run mypy src
- uv run pytest tests/test_io.py tests/test_binaural.py tests/test_cli_report.py
