### PR TITLE
#80 サンプル音源の高レート出力対応

### DIFF
--- a/docs/jp/api-cli-reference.md
+++ b/docs/jp/api-cli-reference.md
@@ -12,7 +12,8 @@ uv run microstructure-metrics generate <signal_type> [options]
 ```
 - `signal_type`: thd / notched-noise / pink-noise / modulated / tfs-tones / tone-burst / am-attack / click / complex-bass / binaural-cues / ms-side-texture
 - 主なオプション:
-  - `--sample-rate,-sr` (int, default 48000)
+  - `--sample-rate,-sr` (int, default 48000, 8k〜768kHz)
+    - 44.1k/48k 系の16x（705.6 / 768 kHz）出力に対応
   - `--bit-depth,-bd` ("24bit" or "32f")
   - `--duration,-d` (sec, default 10.0) テスト本体長
   - 出力チャンネル: **常にステレオ(2ch)**（モノラル信号はL/R複製、binaural系は左右で差分あり）

--- a/src/microstructure_metrics/cli/generate.py
+++ b/src/microstructure_metrics/cli/generate.py
@@ -41,9 +41,9 @@ def _parse_float_list(text: str) -> list[float]:
     "--sample-rate",
     "-sr",
     default=48000,
-    type=click.IntRange(8000, 384000),
+    type=click.IntRange(8000, 768000),
     show_default=True,
-    help="サンプルレート (Hz)",
+    help="サンプルレート (Hz, 8k〜768k、705.6/768k 対応)",
 )
 @click.option(
     "--bit-depth",

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -160,6 +160,30 @@ def test_generate_tfs_tones_defaults(tmp_path: Path) -> None:
     assert data.shape[1] == 2
 
 
+def test_generate_supports_high_sample_rate(tmp_path: Path) -> None:
+    runner = CliRunner()
+    wav_path = tmp_path / "thd_768000.wav"
+    result = runner.invoke(
+        main,
+        [
+            "generate",
+            "thd",
+            "--duration",
+            "0.05",
+            "--sample-rate",
+            "768000",
+            "--output",
+            str(wav_path),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    data, sample_rate = sf.read(wav_path, always_2d=True)
+    assert sample_rate == 768000
+    assert data.ndim == 2
+    assert data.shape[0] > 0
+
+
 @pytest.mark.parametrize(
     "signal_type,opts",
     [


### PR DESCRIPTION
## Summary
- expand `generate`'s `--sample-rate` range to 8 kHz through 768 kHz so 705.6/768 kHz test signals can be generated
- document the high-rate capability in the Japanese CLI reference
- add a regression test that generates a 768 kHz THD file and reads it back

## Testing
- `uv run pytest tests/test_generate.py`

Closes #80