### PR TITLE
#73 docs: clarify new microstructure metrics/stimuli

### DIFF
--- a/docs/en/metrics-interpretation.md
+++ b/docs/en/metrics-interpretation.md
@@ -13,6 +13,7 @@ Purpose: explain how to read the metrics produced by `report` (JSON/CSV/Markdown
 - Edge rounding / transient smearing → Transient metrics (needs impulse/edge stimulus).
 - Bass waveform fidelity → LFCR.
 - Spatial cue stability (stereo) → BCP.
+- Distribution-distance comparisons → MDI.
 - Residual “structure” vs noise → RMI.
 - Always use the intended stimulus from `docs/*/signal-specifications.md`; wrong signals make metrics meaningless.
 
@@ -58,6 +59,11 @@ Purpose: explain how to read the metrics produced by `report` (JSON/CSV/Markdown
 - Burstiness: `burstiness.kurtosis`, `burstiness.crest_factor`, `burstiness.p99_abs` (higher → more impulsive/structured).
 - Whiteness: `whiteness.spectral_flatness` (closer to 1 → flatter), `whiteness.autocorr_peak_excess` (closer to 0 → more white), `whiteness.autocorr_peak_lag_ms`.
 - Modulation structure: `modulation.high_mod_ratio_4_64`, `modulation.high_mod_ratio_10_64` (higher → more high-rate envelope modulation in residual).
+
+### Microstructure Distribution Divergence (MDI)
+- What: compares short-time feature distributions from TFS, Transient (and, when available, BCP) using 1D Wasserstein distances so that “mostly OK but sometimes broken” behavior is highlighted.
+- Where in JSON: `metrics.divergence`. See `mdi_total`, `channels_total`/`binaural_total`, `component_totals`, and the list of `components` describing per-feature contributions (e.g., `ch0.tfs.correlation_to_ideal`, `ch0.transient.attack_time_ms`, `binaural.ild_db`).
+- Heuristic: lower `mdi_total` signals more similar distributions. Component breakdowns show which feature (e.g., TFS correlation → 1.0, band delay → 0 ms, transient attack/width, binaural ITD/ILD/IACC) is drifting; even if averages look fine, a large component indicates sporadic glitched frames or localized degradation.
 
 ## Reading examples
 - “MPS corr 0.75, TFS corr 0.8”: both texture and high-band phase are degraded—could be heavy feedback or bandwidth limits.

--- a/docs/en/signal-specifications.md
+++ b/docs/en/signal-specifications.md
@@ -17,6 +17,9 @@ Scope: define test signal structure, file/metadata formats, and naming rules for
 | MPS | AM/FM composite | 1 kHz carrier, AM 4 Hz depth 50%, FM dev 50 Hz @4 Hz, peak≈-6 dBFS, 8 s |
 | TFS | High-band multitone | 4/6/8/10/12 kHz, equal amplitude, peak≈-6 dBFS, 8 s |
 | Transient | Impulse / tone burst train | Spaced impulses or bursts, peak near -1 dBFS, 0.3–1.0 s |
+| LFCR | complex-bass | 30–220 Hz FM/PM multi-tone, 8 components, peak≈-2 dBFS |
+| BCP | binaural-cues | 150 Hz–Nyquist pink noise with ITD 0.35 ms and ILD 6 dB, replayed as stereo peak≈-3 dBFS |
+| RMI/MDI | ms-side-texture | Mid: 80–3.2 kHz pink noise, Side: 4+ kHz modulated tones, peak≈-3 dBFS for side-rich microstructure |
 
 ## File format
 - Sample rate: 48 kHz required (96 kHz only when explicitly needed).
@@ -38,12 +41,16 @@ pink_noise_48000_24bit_v1.wav
 - `version`: bump when parameters change (vN or semver).
 - Optional parameters can follow signal_type (e.g., `mps_1khz_am4hz50_fm50hz_48000_24bit_v1.wav`).
 
-## Metadata JSON (sidecar)
+-## Metadata JSON (sidecar)
 - Required keys:
   - `signal_type` (str), `sample_rate` (int), `bit_depth` (str), `channels` (int)
   - `duration_sec` (float), `pilot_tone_freq_hz` (int), `pilot_duration_ms` (int)
   - `pilot_level_dbfs` (float), `lead_silence_ms` / `tail_silence_ms` (int)
   - `version` (str), `created_at` (ISO 8601 UTC)
+- Optional stimulus-specific keys:
+  - `complex-bass`: `bass_components_hz`, `bass_fm_dev_hz`, `bass_fm_rates_hz`, `bass_pm_depth_rad`, `bass_pm_rates_hz`, `band_lowcut_hz`, `band_highcut_hz`, `target_peak_dbfs`
+  - `binaural-cues`: `itd_ms`, `ild_db`, `base_noise_lowcut_hz`, `base_noise_highcut_hz`, `target_peak_dbfs`
+  - `ms-side-texture`: `mid_band_lowcut_hz`, `mid_band_highcut_hz`, `side_tones_hz`, `side_mod_freq_hz`, `side_mod_depth`, `side_target_peak_dbfs`, `target_peak_dbfs`
 - Example:
 ```json
 {
@@ -72,6 +79,12 @@ pink_noise_48000_24bit_v1.wav
 - Sample rate / bit depth / channels match filename and metadata.
 - Peak ≤ -1 dBFS; pilots ≈ -6 dBFS; no clipping; 5 ms fades applied.
 - Metadata JSON exists and is consistent with the signal.
+
+## New stimuli / stereo signals
+- `complex-bass` layers 8 FM/PM-modulated tones between 30–220 Hz to exercise LFCR’s cycle-shape / phase-coherence checks. The resulting waveform is duplicated to stereo so the low-frequency phase structure can still be tracked per channel.
+- `binaural-cues` generates pink noise above 150 Hz and introduces an ITD (default 0.35 ms) plus ILD (default 6 dB) between L/R. This signal targets BCP’s ITD/ILD/IACC sections and keeps the stereo timeline intact for `report --channels stereo|mid|side`.
+- `ms-side-texture` mixes mid-range pink noise (80–3.2 kHz) with high-frequency side tones (≳4 kHz) modulated at 5 Hz. The resulting mid/side stereo is ideal for RMI/MDI to pick up residual microstructure differences in the Side channel while still preserving a natural Mid reference.
+- When using these stereo stimuli, keep the `align`/`drift`/`report` pipeline on 2ch and prefer `report --channels stereo` (default) or `mid`/`side` so BCP/MDI can consume all available features (`ch0`/`ch1` disables stereo-specific metrics).
 
 ## Related docs
 - Measurement setup (EN): `docs/en/measurement-setup.md`

--- a/docs/en/user-guide.md
+++ b/docs/en/user-guide.md
@@ -5,7 +5,8 @@ This guide is for end users who measure and compare DAC/AMP devices using the CL
 ## What you get
 - Pilot-tone-based alignment and drift estimation
 - Test signal generation (THD, pink-noise, AM/FM, TFS tones, transient clicks/bursts)
-- Metrics: THD+N, MPS, TFS, Transient, LFCR, BCP, RMI
+- Metrics: THD+N, MPS, TFS, Transient, LFCR, BCP, RMI, MDI
+- New stimuli such as `complex-bass`, `binaural-cues`, and `ms-side-texture` exercise LFCR/BCP/RMI/MDI.
 - Reports in JSON/CSV/Markdown, optional plots for MPS/TFS/BCP/LFCR/RMI
 
 ## Prerequisites
@@ -22,6 +23,7 @@ uv sync
 ## Typical workflow
 1) Generate or download the test signal
    - Example: `uv run microstructure-metrics generate notched-noise --with-metadata`
+   - Stereo stimuli: `generate complex-bass`, `binaural-cues`, or `ms-side-texture` to hit LFCR/BCP/RMI/MDI.
 2) Play and record the DUT path with bit-perfect playback (no EQ/AGC/SRC). Keep the file untrimmed.
 3) Align ref/dut using pilots
    - `uv run microstructure-metrics align ref.wav dut.wav`
@@ -35,6 +37,8 @@ uv sync
 - Align: `microstructure-metrics align ref.wav dut.wav [options]`
 - Drift: `microstructure-metrics drift ref.wav dut.wav [options]`
 - Report: `microstructure-metrics report ref.wav dut.wav [options]`
+  - `--channels stereo|mid|side` keeps BCP/MDI enabled (default `stereo`; `ch0`/`ch1` runs a single channel only).
+  - `--plot` now emits BCP ITD/ILD heatmaps, BCP IACC time series, LFCR cycle overlays, and RMI residual spectrograms.
 See `docs/api-cli-reference.md` for full option lists (Japanese).
 
 ## Recording tips
@@ -47,7 +51,7 @@ See `docs/api-cli-reference.md` for full option lists (Japanese).
 - Outputs:
   - Aligned WAVs: `*.aligned_ref.wav`, `*.aligned_dut.wav`
   - Drift report (optional JSON)
-  - Metrics report: JSON (default `metrics_report.json`), optional CSV/Markdown
+  - Metrics report: JSON (default `metrics_report.json`), optional CSV/Markdown; JSON now includes `metrics.divergence.mdi_total` representing the Microstructure Distribution Divergence.
   - Plots (when `--plot`): MPS delta heatmap, TFS correlation time-series, BCP ITD/ILD heatmaps, BCP IACC time-series, LFCR cycle shape overlay, RMI residual spectrogram
 
 ## Related docs

--- a/docs/jp/api-cli-reference.md
+++ b/docs/jp/api-cli-reference.md
@@ -73,6 +73,7 @@ uv run microstructure-metrics report ref.wav dut.wav [options]
 - 主なオプション:
   - 入力処理: `--allow-resample` `--target-sample-rate` `--channels`
     - `--channels`: `stereo|mid|side|ch0|ch1` を選択。I/Oは常に2chへ正規化され、mid/sideは2chへ写像、ch0/ch1は指定chを複製して解析する。
+      - BCP/MDI はステレオ入力を前提とするため、`stereo`/`mid`/`side` を使うと全データが活用される（`ch0`/`ch1` では BCP/MDI が利用不可）。
   - アライメント: `--align/--no-align` `--pilot-freq` `--pilot-threshold`
     `--pilot-band-width-hz` `--pilot-duration-ms` `--min-duration-ms`
     `--margin-ms` `--max-lag-ms`
@@ -86,6 +87,7 @@ uv run microstructure-metrics report ref.wav dut.wav [options]
   - LFCR出力項目: `cycle_shape_corr_mean` / `cycle_shape_corr_p05` / `harmonic_phase_coherence` / `envelope_diff_outlier_rate` / 帯域別 `band_metrics.*`
   - RMI(residual)出力項目: `burstiness.kurtosis` / `burstiness.crest_factor` / `burstiness.p99_abs` / `whiteness.spectral_flatness` / `whiteness.autocorr_peak_excess` / `modulation.high_mod_ratio_4_64` など
     - JSON上の参照例: `metrics.ch0.residual.whiteness.spectral_flatness`
+  - MDI（Microstructure Distribution Divergence）: `metrics.divergence` に `mdi_total`/`channels_total`/`binaural_total`/`component_totals`/`components` が入り、TFS/Transient（＋ステレオで BCP）を分布で比較した 1D Wasserstein 距離を重み付き合算した値。小さいほど「局所的な崩れが少ない」。
 - 例: JSON と Markdown を保存
 ```
 uv run microstructure-metrics report ref.aligned_ref.wav dut.aligned_dut.wav \

--- a/docs/jp/signal-specifications.md
+++ b/docs/jp/signal-specifications.md
@@ -19,6 +19,9 @@
 | MPS | AM/FM composite | 1 kHz carrier, AM 4 Hz depth 50%, FM 50 Hz@4 Hz, peak≈-6 dBFS, 8 s |
 | TFS | High-band multitone | 4/6/8/10/12 kHz 等振幅, peak≈-6 dBFS, 8 s |
 | Transient | Impulse / tone burst train | インパルスまたはバースト列、ピーク -1 dBFS 付近、0.3–1.0 s |
+| LFCR | complex-bass (低域複雑ベース) | 30–220 Hz RMSE, 8本のFM/PMトーン, peak≈-2 dBFS |
+| BCP | binaural-cues (ステレオ ITD/ILD) | 150–10 kHz pink noise with controlled ITD 0.35 ms / ILD 6 dB, peak≈-3 dBFS |
+| RMI/MDI | ms-side-texture (Mid/Side で構造化したテクスチャ) | Mid: 80–3.2 kHz pink, Side: 4+ kHz modulated tones, peak≈-3 dBFS |
 
 ## 追加信号（Issue #70）
 - 共通: 標準タイムラインを維持し、48 kHz / 24-bit / stereo。WAVピークは -1 dBFS 以下。
@@ -65,6 +68,10 @@ pink_noise_48000_24bit_v1.wav
   - `duration_sec` (float), `pilot_tone_freq_hz` (int), `pilot_duration_ms` (int)
   - `pilot_level_dbfs` (float), `lead_silence_ms` / `tail_silence_ms` (int)
   - `version` (str), `created_at` (ISO8601, UTC)
+- 追加キー（刺激ごとに差分あり）:
+  - `complex-bass`: `bass_components_hz`, `bass_fm_dev_hz`, `bass_fm_rates_hz`, `bass_pm_depth_rad`, `bass_pm_rates_hz`, `band_lowcut_hz`, `band_highcut_hz`, `target_peak_dbfs`
+  - `binaural-cues`: `itd_ms`, `ild_db`, `base_noise_lowcut_hz`, `base_noise_highcut_hz`, `target_peak_dbfs`
+  - `ms-side-texture`: `mid_band_lowcut_hz`, `mid_band_highcut_hz`, `side_tones_hz`, `side_mod_freq_hz`, `side_mod_depth`, `side_target_peak_dbfs`, `target_peak_dbfs`
 - 例:
 ```json
 {
@@ -94,6 +101,12 @@ pink_noise_48000_24bit_v1.wav
 - ピーク ≤ -1 dBFS、クリップなし。パイロットはおよそ -6 dBFS。
 - パイロットに5 msフェードが入り、無音区間が残されている。
 - メタデータJSONが存在し、内容が信号と整合。
+
+## 新刺激 / ステレオ構成
+- `complex-bass` は 30–220 Hz の低域マルチトーン（FM/PM 調整）を重ねて LFCR の周期波形差に敏感な低域テクスチャを作る。LR はタイムライン内で複製されるが、波形のわずかな群遅延や位相差が再現性評価に反映される。
+- `binaural-cues` は 150 Hz 以上のピンクノイズを生成し、右チャンネルに ITD（デフォルト 0.35 ms）、ILD（デフォルト 6 dB）を付加することで BCP の ITD/ILD/IACC セクションをストレステストする。`report --channels stereo`/`mid`/`side` で解析ができ、ステレオ依存の可視化（例: ITD/ILD ヒートマップ）も有効になる。
+- `ms-side-texture` では Mid チャンネルに 80–3.2 kHz のピンクノイズ、Side に 4 kHz 以上の変調トーン群 + 5 Hz の振幅モジュレーションを与えて、Side 周波数帯の高変調/位相構造を RMI/MDI で観察する。Mid/Side の分解は `report --channels mid|side` で明示的に行うこともできる。
+- これらのステレオ刺激を使う場合、`align`/`drift`/`report` は 2ch のまま処理し、`report --channels` に `stereo` を選ぶことで BCP/MDI が利用可能になる（`ch0`/`ch1` で片チャンネルを選ぶと BCP は利用不可になる）。
 
 ## 関連ドキュメント
 - 測定手順: `docs/jp/measurement-setup.md`


### PR DESCRIPTION
## Summary
- document the new LFCR/BCP/RMI/MDI stimuli and metadata in both JP/EN signal spec guides
- spell out MDI plus the stereo/plot guidance across JP/EN interpretation, CLI, and user guides

## Testing
- ============================= test session starts ==============================
platform linux -- Python 3.14.0, pytest-9.0.2, pluggy-1.6.0 -- /home/michihito/Working/microstructure-metrics/worktrees/mm-73/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/michihito/Working/microstructure-metrics/worktrees/mm-73
configfile: pyproject.toml
testpaths: tests
plugins: cov-7.0.0
collecting ... collected 98 items

tests/test_alignment.py::test_detect_pilot_tones_finds_two_segments PASSED [  1%]
tests/test_alignment.py::test_extract_test_segment_matches_body_length PASSED [  2%]
tests/test_alignment.py::test_estimate_delay_recovers_integer_shift PASSED [  3%]
tests/test_alignment.py::test_align_audio_pair_end_to_end PASSED         [  4%]
tests/test_alignment.py::test_align_signals_trims_to_shorter_after_shift PASSED [  5%]
tests/test_alignment.py::test_cli_align_outputs_files PASSED             [  6%]
tests/test_bass.py::test_lfcr_detects_phase_warp PASSED                  [  7%]
tests/test_binaural.py::test_binaural_cue_preservation_recovers_itd_and_ild PASSED [  8%]
tests/test_cli_drift.py::test_cli_drift_none PASSED                      [  9%]
tests/test_cli_drift.py::test_cli_drift_strict_high PASSED               [ 10%]
tests/test_cli_report.py::test_cli_report_outputs_json_csv_md PASSED     [ 11%]
tests/test_cli_report.py::test_cli_report_channels_stereo PASSED         [ 12%]
tests/test_cli_report.py::test_cli_report_no_align_with_resample PASSED  [ 13%]
tests/test_cli_report.py::test_cli_report_fails_without_resample_permission PASSED [ 14%]
tests/test_divergence.py::test_mdi_wasserstein_detects_local_breakdown_even_when_mean_matches PASSED [ 15%]
tests/test_divergence.py::test_mdi_increases_for_phase_warp_and_transient_smearing PASSED [ 16%]
tests/test_drift.py::test_estimate_clock_drift_no_drift PASSED           [ 17%]
tests/test_drift.py::test_estimate_clock_drift_positive_ppm PASSED       [ 18%]
tests/test_drift.py::test_check_drift_threshold_levels PASSED            [ 19%]
tests/test_drift.py::test_estimate_clock_drift_accepts_stereo_input PASSED [ 20%]
tests/test_generate.py::test_generate_thd_creates_wav_and_json PASSED    [ 21%]
tests/test_generate.py::test_generate_thd_stereo_channels PASSED         [ 22%]
tests/test_generate.py::test_generate_tfs_tones_defaults PASSED          [ 23%]
tests/test_generate.py::test_generate_supports_high_sample_rate PASSED   [ 24%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[notched-noise-opts0] PASSED [ 25%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[pink-noise-opts1] PASSED [ 26%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[modulated-opts2] PASSED [ 27%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[tone-burst-opts3] PASSED [ 28%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[am-attack-opts4] PASSED [ 29%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[click-opts5] PASSED [ 30%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[complex-bass-opts6] PASSED [ 31%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[binaural-cues-opts7] PASSED [ 32%]
tests/test_generate.py::test_generate_other_signals_structure_and_pilot[ms-side-texture-opts8] PASSED [ 33%]
tests/test_generate.py::test_generate_transient_signals_metadata_keys[tone-burst-opts0-expected_keys0] PASSED [ 34%]
tests/test_generate.py::test_generate_transient_signals_metadata_keys[am-attack-opts1-expected_keys1] PASSED [ 35%]
tests/test_generate.py::test_generate_transient_signals_metadata_keys[click-opts2-expected_keys2] PASSED [ 36%]
tests/test_generate.py::test_generate_new_signals_metadata[complex-bass-opts0-expected_keys0] PASSED [ 37%]
tests/test_generate.py::test_generate_new_signals_metadata[binaural-cues-opts1-expected_keys1] PASSED [ 38%]
tests/test_generate.py::test_generate_new_signals_metadata[ms-side-texture-opts2-expected_keys2] PASSED [ 39%]
tests/test_generate.py::test_pilot_frequency_and_level PASSED            [ 40%]
tests/test_generate.py::test_notched_noise_has_attenuation PASSED        [ 41%]
tests/test_generate.py::test_generate_notched_noise_multi_centers_and_cascade_metadata PASSED [ 42%]
tests/test_generate.py::test_generate_notched_noise_q_sweep_creates_multiple_files PASSED [ 43%]
tests/test_generate.py::test_pink_noise_spectral_slope PASSED            [ 44%]
tests/test_generate.py::test_modulated_has_am_depth PASSED               [ 45%]
tests/test_generate.py::test_complex_bass_energy_focus PASSED            [ 46%]
tests/test_generate.py::test_binaural_cues_itd_and_ild PASSED            [ 47%]
tests/test_generate.py::test_ms_side_texture_side_energy_high_band PASSED [ 48%]
tests/test_generate.py::test_tfs_tones_peak_frequencies PASSED           [ 50%]
tests/test_io.py::test_load_audio_pair_returns_validation_and_metadata PASSED [ 51%]
tests/test_io.py::test_sample_rate_mismatch_requires_resample_option PASSED [ 52%]
tests/test_io.py::test_bit_depth_mismatch_is_warning PASSED              [ 53%]
tests/test_io.py::test_quality_checks_detect_clipping_dc_and_silence PASSED [ 54%]
tests/test_io.py::test_stereo_input_keeps_two_channels_without_warning PASSED [ 55%]
tests/test_io.py::test_multi_channel_input_is_truncated_to_two_channels PASSED [ 56%]
tests/test_io.py::test_channels_option_stereo_mid_side PASSED            [ 57%]
tests/test_io.py::test_channels_option_ch0_ch1 PASSED                    [ 58%]
tests/test_io.py::test_normalize_peak_and_rms PASSED                     [ 59%]
tests/test_io.py::test_dc_removal_highpass PASSED                        [ 60%]
tests/test_io.py::test_resample_preserves_length_and_warns PASSED        [ 61%]
tests/test_io.py::test_target_sample_rate_without_flag_resamples_and_warns PASSED [ 62%]
tests/test_io.py::test_custom_thresholds_for_warnings PASSED             [ 63%]
tests/test_io.py::test_bit_depth_mapping[PCM_16-16] PASSED               [ 64%]
tests/test_io.py::test_bit_depth_mapping[PCM_24-24] PASSED               [ 65%]
tests/test_io.py::test_bit_depth_mapping[FLOAT-32] PASSED                [ 66%]
tests/test_io.py::test_duration_bounds_warnings PASSED                   [ 67%]
tests/test_mps.py::test_mps_detects_am_modulation_peak PASSED            [ 68%]
tests/test_mps.py::test_mps_similarity_high_for_identical_signals PASSED [ 69%]
tests/test_mps.py::test_mps_similarity_degrades_when_modulation_removed PASSED [ 70%]
tests/test_mps.py::test_mps_similarity_high_mod_weighting_emphasizes_high_mod_errors PASSED [ 71%]
tests/test_mps.py::test_mps_supports_log_modulation_axis PASSED          [ 72%]
tests/test_mps.py::test_mps_mel_filterbank_runs PASSED                   [ 73%]
tests/test_mps.py::test_mps_rectify_envelope_detects_modulation PASSED   [ 74%]
tests/test_mps.py::test_mps_similarity_band_weighting PASSED             [ 75%]
tests/test_mps.py::test_mps_handles_am_fm_composite_on_log_grid PASSED   [ 76%]
tests/test_regression.py::test_regression_against_expected[harmonic_distortion] PASSED [ 77%]
tests/test_regression.py::test_regression_against_expected[soft_clipping] PASSED [ 78%]
tests/test_regression.py::test_regression_against_expected[band_limit] PASSED [ 79%]
tests/test_regression.py::test_regression_against_expected[noise_floor] PASSED [ 80%]
tests/test_regression.py::test_regression_against_expected[phase_distortion] PASSED [ 81%]
tests/test_regression.py::test_regression_against_expected[modulation_suppression] PASSED [ 82%]
tests/test_regression.py::test_regression_against_expected[modulation_composite] PASSED [ 83%]
tests/test_regression.py::test_regression_against_expected[edge_rounding_click] PASSED [ 84%]
tests/test_regression.py::test_regression_against_expected[time_smoothing_attack] PASSED [ 85%]
tests/test_regression.py::test_regression_against_expected[tone_burst_smearing] PASSED [ 86%]
tests/test_residual.py::test_residual_microstructure_separates_noise_and_ringing PASSED [ 87%]
tests/test_tfs.py::test_extract_tfs_returns_expected_components PASSED   [ 88%]
tests/test_tfs.py::test_tfs_correlation_high_for_identical_signals PASSED [ 89%]
tests/test_tfs.py::test_tfs_correlation_degrades_with_phase_modulation PASSED [ 90%]
tests/test_tfs.py::test_tfs_skips_low_envelope_frames PASSED             [ 91%]
tests/test_tfs.py::test_tfs_phase_coherence_is_robust_to_constant_delay PASSED [ 92%]
tests/test_thd_n.py::test_thd_n_detects_harmonic_and_noise_components PASSED [ 93%]
tests/test_thd_n.py::test_thd_n_respects_bandwidth_and_harmonic_count PASSED [ 94%]
tests/test_thd_n.py::test_gain_warning_when_fundamental_far_from_expected PASSED [ 95%]
tests/test_transient.py::test_transient_metrics_detect_smearing_multi_events PASSED [ 96%]
tests/test_transient.py::test_transient_metrics_identical_signals_multi_events_neutral PASSED [ 97%]
tests/test_transient.py::test_transient_metrics_supports_zero_smoothing_and_new_features PASSED [ 98%]
tests/test_transient.py::test_transient_metrics_pre_energy_distinguishes_zero_phase_vs_causal PASSED [100%]

============================= 98 passed in 14.62s ==============================

Closes #73