### PR TITLE
Add visual-friendly stereo/BCP test data generators

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ uv run pytest
 uv run pre-commit run --all-files
 ```
 
+### Visual-friendly test data (local)
+
+This repo does not commit WAV files, but you can generate deterministic ref/dut pairs for
+easy visualization:
+
+```bash
+python tests/generate_test_data.py --profile visual --output-dir ./_visual_test_data
+```
+
 ## Project layout
 
 ```

--- a/README_JP.md
+++ b/README_JP.md
@@ -86,6 +86,14 @@ uv run pytest
 uv run pre-commit run --all-files
 ```
 
+### 可視化しやすいテストデータ（ローカル生成）
+
+WAV はリポジトリに含めませんが、可視化しやすい決定的(ref/dut)ペアを生成できます。
+
+```bash
+python tests/generate_test_data.py --profile visual --output-dir ./_visual_test_data
+```
+
 ## プロジェクト構成
 
 ```

--- a/tests/generate_test_data.py
+++ b/tests/generate_test_data.py
@@ -39,6 +39,7 @@ def _visualization_pairs(
     """可視化用に差分が分かりやすいテストペアを返す（WAVはgit管理しない想定）。"""
     common = CommonSignalConfig(sample_rate=sample_rate, duration=2.0)
     rng_seed = 0
+    fixed_created_at = "2000-01-01T00:00:00+00:00"
 
     cases: list[
         tuple[
@@ -74,8 +75,8 @@ def _visualization_pairs(
             dut.data,
             common.sample_rate,
             "binaural_cues_itd0.2ms_ild0_to_itd0.6ms_ild6",
-            ref.metadata,
-            dut.metadata,
+            {**ref.metadata, "created_at": fixed_created_at},
+            {**dut.metadata, "created_at": fixed_created_at},
         )
     )
 
@@ -104,8 +105,12 @@ def _visualization_pairs(
             dut_ms,
             common.sample_rate,
             "ms_side_texture_side_gain",
-            ref_ms.metadata,
-            {**ref_ms.metadata, "side_gain": float(side_gain)},
+            {**ref_ms.metadata, "created_at": fixed_created_at},
+            {
+                **ref_ms.metadata,
+                "created_at": fixed_created_at,
+                "side_gain": float(side_gain),
+            },
         )
     )
 


### PR DESCRIPTION
Closes #90

- `tests/generate_test_data.py` に `--profile visual` を追加
- 可視化しやすい決定的(stable)なステレオペアを追加
  - BCP向け: `binaural-cues` の ITD/ILD 差分
  - ステレオ向け: M/S テクスチャの side 成分増減

Notes:
- WAV は `.gitignore` によりコミットされません（生成して手元で可視化する用途）。
