### PR TITLE
docs(metrics): add LFCR documentation

### DIFF
--- a/docs/en/metrics/lfcr.md
+++ b/docs/en/metrics/lfcr.md
@@ -1,0 +1,314 @@
+# Low-Frequency Complex Reconstruction (LFCR)
+
+## 1. Overview
+
+### Purpose and Significance
+
+**Low-Frequency Complex Reconstruction (LFCR)** evaluates how faithfully a device
+reproduces **low-frequency waveform structure** (bass) when the signal contains
+non-trivial phase / FM / PM variation. Unlike steady-state metrics (e.g. THD+N),
+LFCR targets degradation that often shows up as “loose”, “blurred”, or
+“phase-warped” bass even when harmonic distortion is low.
+
+LFCR is designed to be sensitive to:
+- Low-frequency group delay / phase distortion
+- Poor interpolation / insufficient taps in resampling or reconstruction
+- Bass envelope glitches (local instability) that do not appear as simple noise
+
+### What it Measures
+
+LFCR operates on one channel at a time (after alignment) and summarizes three
+complementary checks, computed per low-frequency band:
+
+1. **Cycle-shape correlation**: compare the waveform shape of each cycle after
+   reparameterizing by instantaneous phase (phase-conditioned resampling).
+2. **Harmonic phase coherence**: compare relative phase relationships between
+   harmonics (2nd..N) conditioned on the fundamental.
+3. **Envelope-difference outlier rate**: detect local envelope-gradient
+   mismatches (glitches / instability) relative to the reference baseline.
+
+### Typical Applications
+
+- Evaluating resampler / reconstruction quality in bass-heavy content
+- Detecting phase-warping or low-frequency timing smear in DAC/AMP chains
+- Comparing bass “tightness” between devices under the same stimulus
+
+---
+
+## 2. Mathematical Definition
+
+Let \(x^{(\mathrm{ref})}[n]\) and \(x^{(\mathrm{dut})}[n]\) be aligned 1-D
+signals sampled at \(f_s\) Hz.
+
+### 2.1 Bandpass Filtering
+
+For each low-frequency band \(b = [f_{\ell}, f_h]\), apply a Butterworth
+bandpass filter and use zero-phase filtering:
+
+$$
+y_b[n] = \mathrm{filtfilt}\left(\mathrm{Butter}(n, f_{\ell}, f_h), x[n]\right)
+$$
+
+The implementation uses second-order sections and `sosfiltfilt`.
+
+### 2.2 Analytic Signal, Envelope, and Phase
+
+For the reference band signal \(y_b^{(\mathrm{ref})}[n]\), form the analytic
+signal via the Hilbert transform:
+
+$$
+z_b[n] = y_b^{(\mathrm{ref})}[n] + j\,\mathcal{H}\{y_b^{(\mathrm{ref})}[n]\}
+$$
+
+Envelope and unwrapped phase:
+
+$$
+A_b[n] = |z_b[n]|,\quad \phi_b[n] = \mathrm{unwrap}(\arg(z_b[n]))
+$$
+
+### 2.3 Cycle Segmentation (Phase-Conditioned)
+
+Define a cycle index from the accumulated phase:
+
+$$
+c[n] = \left\lfloor \frac{\phi_b[n] - \phi_b[0]}{2\pi} \right\rfloor
+$$
+
+For each cycle \(c\), accept it if:
+- it has at least 2 samples,
+- its phase span is at least \(0.75\cdot 2\pi\),
+- its mean envelope exceeds a threshold \(A_{\min}\).
+
+The envelope threshold is derived from the global peak level of
+\(x^{(\mathrm{ref})}\) and \(x^{(\mathrm{dut})}\) using
+`envelope_threshold_db`.
+
+### 2.4 Cycle Shape Resampling on a Phase Grid
+
+For an accepted cycle, build a phase grid of \(P\) points:
+
+$$
+\theta_k = \frac{2\pi k}{P}, \quad k = 0,\ldots,P-1
+$$
+
+Let \(\phi_c[n]\) be the phase within the cycle shifted so it starts at 0.
+Interpolate both reference and DUT band signals on \(\theta_k\):
+
+$$
+s^{(\mathrm{ref})}_c[k] = \mathrm{interp}(\theta_k,\phi_c, y_b^{(\mathrm{ref})}),
+\quad
+s^{(\mathrm{dut})}_c[k] = \mathrm{interp}(\theta_k,\phi_c, y_b^{(\mathrm{dut})})
+$$
+
+### 2.5 Cycle-Shape Correlation
+
+Compute the Pearson correlation for each cycle:
+
+$$
+\rho_c =
+\frac{\sum_k (s^{(\mathrm{ref})}_c[k]-\bar{s}^{(\mathrm{ref})}_c)
+(s^{(\mathrm{dut})}_c[k]-\bar{s}^{(\mathrm{dut})}_c)}
+{\sqrt{\sum_k (s^{(\mathrm{ref})}_c[k]-\bar{s}^{(\mathrm{ref})}_c)^2}
+\sqrt{\sum_k (s^{(\mathrm{dut})}_c[k]-\bar{s}^{(\mathrm{dut})}_c)^2}}
+$$
+
+Use the mean envelope in the cycle as its weight:
+
+$$
+w_c = \frac{1}{|c|}\sum_{n\in c} A_b[n]
+$$
+
+Aggregate across all cycles and bands:
+- `cycle_shape_corr_mean`: weighted mean of \(\rho_c\)
+- `cycle_shape_corr_p05`: weighted 5th percentile of \(\rho_c\)
+
+### 2.6 Fundamental Estimation (Per Band)
+
+Estimate the fundamental frequency \(f_0\) from the reference band using a
+Hann-windowed FFT, selecting the peak magnitude within a search range.
+
+### 2.7 Harmonic Phase Coherence
+
+Compute FFT phases at the nearest bin for \(f_0\) and each harmonic
+\(h f_0\) (for \(h=2,\ldots,H\), below Nyquist).
+
+Define relative harmonic phase (wrapped to \([-\pi,\pi]\)):
+
+$$
+\psi^{(\cdot)}_h =
+\mathrm{wrap}\left(\angle X^{(\cdot)}(h f_0) - h\,\angle X^{(\cdot)}(f_0)\right)
+$$
+
+Then the per-harmonic phase delta is:
+
+$$
+\Delta\psi_h = \mathrm{wrap}\left(\psi^{(\mathrm{dut})}_h
+- \psi^{(\mathrm{ref})}_h\right)
+$$
+
+The coherence score is the resultant length of these phase-difference vectors:
+
+$$
+\mathrm{coherence} =
+\left|\frac{1}{K}\sum_{h=2}^{H} e^{j\Delta\psi_h}\right|
+$$
+
+### 2.8 Envelope-Difference Outlier Rate
+
+Compute envelopes for both signals, normalize by a peak scale, and compare
+envelope gradients:
+
+$$
+g[n] = \Delta\left(\frac{A[n]}{\mathrm{scale}}\right)
+$$
+
+Define a baseline threshold from the reference gradients:
+
+$$
+T = P_{95}(|g^{(\mathrm{ref})}|) + \mathrm{median}(|g^{(\mathrm{ref})}|)
+$$
+
+The outlier rate is:
+
+$$
+r = \frac{1}{N}\sum_n \mathbf{1}\left(|g^{(\mathrm{dut})}[n]
+- g^{(\mathrm{ref})}[n]| > T\right)
+$$
+
+---
+
+## 3. Implementation Details
+
+Implementation lives in `src/microstructure_metrics/metrics/bass.py` as
+`calculate_low_freq_complex_reconstruction()`. In the `report` JSON output this
+metric appears under `metrics.bass.*` (LFCR is the conceptual name).
+
+### 3.1 Parameters and Recommended Values
+
+| Parameter | Type | Default | Notes |
+|-----------|------|---------|------|
+| `sample_rate` | int | – | Sample rate (Hz) |
+| `bands_hz` | sequence of pairs | ((20,80),(80,200)) | Low-frequency bands (Hz) |
+| `filter_order` | int | 4 | Butterworth bandpass order (zero-phase) |
+| `cycle_points` | int | 128 | Samples per phase-conditioned cycle |
+| `envelope_threshold_db` | float | -50.0 | Relative threshold vs global peak |
+| `harmonic_max_order` | int | 5 | Use harmonics 2..N below Nyquist |
+| `fundamental_search_hz` | (float,float) | (30,180) | Fundamental search range (Hz) |
+
+### 3.2 Pseudo Code
+
+The implementation follows the definitions in Section 2:
+
+1. Bandpass `reference`/`dut` per band (`sosfiltfilt`).
+2. Extract reference analytic phase/envelope, segment into cycles, and compute
+   cycle-shape correlations on a fixed phase grid.
+3. Estimate a per-band fundamental from the reference FFT, then compute harmonic
+   phase coherence (resultant length of phase-delta vectors).
+4. Compute envelope-gradient mismatch outlier rate.
+5. Aggregate cycle metrics by cycle envelope weights; aggregate coherence/outlier
+   rate by per-band RMS weight.
+
+### 3.3 Edge Cases and Special Handling
+
+- Inputs must be 1-D and equal length; empty inputs raise `ValueError`.
+- Bands must satisfy `0 < low < high < Nyquist`; otherwise `ValueError`.
+- If no valid cycles are found in a band (too short or too quiet), that band’s
+  cycle metrics become 0.0 and contribute no cycle weights.
+- If the fundamental estimate is invalid (\(f_0 \le 0\)), harmonic coherence is
+  0.0 for that band.
+
+### 3.4 Computational Complexity
+
+For \(B\) bands and \(N\) samples:
+- Filtering: \(\mathcal{O}(B\cdot N)\)
+- Hilbert + FFT (per band): \(\mathcal{O}(B\cdot N\log N)\)
+- Cycle interpolation: \(\mathcal{O}(C\cdot P)\) where \(C\) is used cycles
+
+---
+
+## 4. Interpretation Guidelines
+
+### 4.1 Key Outputs
+
+Higher is better:
+- `cycle_shape_corr_mean`, `cycle_shape_corr_p05` (ideal: close to 1.0)
+- `harmonic_phase_coherence` (ideal: close to 1.0)
+
+Lower is better:
+- `envelope_diff_outlier_rate` (ideal: close to 0.0)
+
+Per-band details are available under `band_metrics`, including `fundamental_hz`
+and the harmonic orders used.
+
+### 4.2 Practical Heuristics
+
+- **High mean, low p05**: mostly OK but intermittent cycle-shape failures
+  (local glitches, time-varying warp, or occasional clipping).
+- **Low harmonic coherence** with decent cycle correlations: waveform shape is
+  similar, but harmonic timing/phase relationships drift (phase warping).
+- **High outlier rate**: envelope micro-instability; often correlates with
+  audible “flutter” or inconsistent bass punch.
+
+LFCR is sensitive to alignment and low-frequency timing; ensure pilot-based
+alignment is successful before trusting values.
+
+---
+
+## 5. Recommended Test Signals
+
+LFCR is most informative on low-frequency content with intentional phase/FM/PM
+structure.
+
+### 5.1 Signal Types
+
+- **complex-bass** (`complex-bass`): 8-component FM/PM multi-tone in ~30–220 Hz
+  (recommended default for LFCR).
+- **Kick + bass composites**: real-world bass waveforms with complex phase.
+- **Low-frequency multitone** with controlled phase offsets.
+
+### 5.2 Example (CLI)
+
+```
+uv run microstructure-metrics generate complex-bass \
+  --duration 10 --sample-rate 48000 --lowcut 30 --highcut 220 \
+  --output ref.wav
+
+uv run microstructure-metrics report ref.wav dut.wav \
+  --output-json report.json --plot
+```
+
+---
+
+## 6. References
+
+### Theoretical Background
+
+- **Auditory Science**: Moore, B. C. J. (2012). *An Introduction to the
+  Psychology of Hearing* (6th ed.). Brill.
+
+### Implementation References
+
+- **SciPy Signal Processing**: https://docs.scipy.org/doc/scipy/reference/signal.html
+- **NumPy FFT**: https://numpy.org/doc/stable/reference/routines.fft.html
+
+### Related Documentation
+
+- **Metrics Interpretation Guide**: `docs/en/metrics-interpretation.md`
+- **Signal Specifications**: `docs/en/signal-specifications.md`
+- **Measurement Setup**: `docs/en/measurement-setup.md`
+
+### Source Code
+
+- **LFCR (bass) Implementation**: `src/microstructure_metrics/metrics/bass.py`
+- **Signal Generation (complex-bass)**: `src/microstructure_metrics/signals/generator.py`
+- **LFCR Visualization**: `src/microstructure_metrics/visualization.py`
+
+---
+
+## Appendix: Common LFCR Pitfalls
+
+1. **Using the wrong stimulus**: pure sines or steady noise do not stress LFCR.
+2. **Skipping alignment**: small time offsets in bass heavily affect cycle
+   comparisons.
+3. **Too short duration**: insufficient cycles yield unstable percentiles.
+4. **Level mismatch / clipping**: distorts cycle shape and envelope gradients.

--- a/docs/jp/metrics/lfcr.md
+++ b/docs/jp/metrics/lfcr.md
@@ -1,0 +1,298 @@
+# 低周波複素再構成 (LFCR: Low-Frequency Complex Reconstruction)
+
+## 1. 概要
+
+### 目的と意義
+
+**低周波複素再構成 (LFCR)** は、低域（ベース帯域）の**波形構造**がどれだけ忠実に
+再現されているかを評価します。THD+N のような定常歪み指標では見えにくい
+「ベースの締まり」「位相の回り込み」「低域のにじみ」などを、低域の位相構造に
+敏感な手続きで定量化することを狙います。
+
+LFCR が検出しやすい劣化例：
+- 低域の群遅延や位相歪み（フィルタや再構成の影響）
+- リサンプル／補間／タップ不足による低域の波形崩れ
+- 包絡の局所的な不安定（グリッチ）によるパンチ感の乱れ
+
+### 測定対象
+
+LFCR は（整列後の）1ch 信号を対象に、低域帯域ごとに以下を併用して評価します：
+
+1. **周期波形形状相関**：参照の瞬時位相で周期を区切り、位相に沿って再サンプルした
+   1周期波形同士の相関をとる（位相条件付き比較）。
+2. **倍音位相コヒーレンス**：基本周波数に条件付けた相対倍音位相の整合度を見る。
+3. **包絡差アウトライア率**：包絡勾配（差分）のズレが参照の自然変動を超える割合を
+   推定し、局所的な不安定を検出する。
+
+### 典型的な用途
+
+- 低域が強い素材での DAC/AMP チェーン比較
+- 低域の位相ワープ、タイミングの smear（にじみ）、補間由来の波形崩れ検出
+- デバイス間の「ベースの締まり」差の定量化
+
+---
+
+## 2. 数学的定義
+
+整列済み 1-D 信号 \(x^{(\mathrm{ref})}[n]\), \(x^{(\mathrm{dut})}[n]\) を
+サンプルレート \(f_s\) Hz で観測するとします。
+
+### 2.1 帯域通過フィルタ
+
+各低域帯域 \(b=[f_{\ell}, f_h]\) について Butterworth の帯域通過フィルタを作り、
+ゼロ位相（前後フィルタ）で適用します：
+
+$$
+y_b[n] = \mathrm{filtfilt}\left(\mathrm{Butter}(n, f_{\ell}, f_h), x[n]\right)
+$$
+
+実装では SOS + `sosfiltfilt` を用います。
+
+### 2.2 解析信号・包絡・位相
+
+参照帯域信号 \(y_b^{(\mathrm{ref})}[n]\) からヒルベルト変換で解析信号を得ます：
+
+$$
+z_b[n] = y_b^{(\mathrm{ref})}[n] + j\,\mathcal{H}\{y_b^{(\mathrm{ref})}[n]\}
+$$
+
+包絡とアンラップ位相：
+
+$$
+A_b[n] = |z_b[n]|,\quad \phi_b[n] = \mathrm{unwrap}(\arg(z_b[n]))
+$$
+
+### 2.3 周期の切り出し（位相条件付き）
+
+累積位相から周期IDを定義します：
+
+$$
+c[n] = \left\lfloor \frac{\phi_b[n] - \phi_b[0]}{2\pi} \right\rfloor
+$$
+
+周期 \(c\) は以下を満たすとき有効とします：
+- サンプル数が 2 以上
+- 位相スパンが \(0.75\cdot 2\pi\) 以上
+- 周期内の平均包絡が閾値 \(A_{\min}\) を上回る
+
+包絡閾値は `envelope_threshold_db` を用い、\(x^{(\mathrm{ref})}\) と
+\(x^{(\mathrm{dut})}\) のグローバル最大振幅に対する相対値として決まります。
+
+### 2.4 位相グリッドへの1周期再サンプル
+
+1周期を \(P\) 点の位相グリッドで表します：
+
+$$
+\theta_k = \frac{2\pi k}{P}, \quad k = 0,\ldots,P-1
+$$
+
+周期内位相 \(\phi_c[n]\) を 0 始まりにシフトし、参照／DUT の帯域信号を
+\(\theta_k\) 上へ線形補間します：
+
+$$
+s^{(\mathrm{ref})}_c[k] = \mathrm{interp}(\theta_k,\phi_c, y_b^{(\mathrm{ref})}),
+\quad
+s^{(\mathrm{dut})}_c[k] = \mathrm{interp}(\theta_k,\phi_c, y_b^{(\mathrm{dut})})
+$$
+
+### 2.5 周期波形形状の相関
+
+周期ごとに Pearson 相関を計算します：
+
+$$
+\rho_c =
+\frac{\sum_k (s^{(\mathrm{ref})}_c[k]-\bar{s}^{(\mathrm{ref})}_c)
+(s^{(\mathrm{dut})}_c[k]-\bar{s}^{(\mathrm{dut})}_c)}
+{\sqrt{\sum_k (s^{(\mathrm{ref})}_c[k]-\bar{s}^{(\mathrm{ref})}_c)^2}
+\sqrt{\sum_k (s^{(\mathrm{dut})}_c[k]-\bar{s}^{(\mathrm{dut})}_c)^2}}
+$$
+
+重みは周期内平均包絡：
+
+$$
+w_c = \frac{1}{|c|}\sum_{n\in c} A_b[n]
+$$
+
+全周期・全帯域で集約し：
+- `cycle_shape_corr_mean`：\(\rho_c\) の重み付き平均
+- `cycle_shape_corr_p05`：\(\rho_c\) の重み付き 5 パーセンタイル
+
+### 2.6 基本周波数推定（帯域ごと）
+
+参照帯域に Hann 窓をかけた FFT を用い、探索範囲内の最大振幅ピークの周波数を
+基本周波数 \(f_0\) とします。
+
+### 2.7 倍音位相コヒーレンス
+
+FFT の位相から、基本周波数と倍音 \(h f_0\)（\(h=2,\ldots,H\)）の位相を取得し、
+基本位相に条件付けた相対倍音位相を定義します（\([-\pi,\pi]\) に wrap）：
+
+$$
+\psi^{(\cdot)}_h =
+\mathrm{wrap}\left(\angle X^{(\cdot)}(h f_0) - h\,\angle X^{(\cdot)}(f_0)\right)
+$$
+
+参照との差：
+
+$$
+\Delta\psi_h = \mathrm{wrap}\left(\psi^{(\mathrm{dut})}_h
+- \psi^{(\mathrm{ref})}_h\right)
+$$
+
+位相差ベクトルの平均長をコヒーレンスとします：
+
+$$
+\mathrm{coherence} =
+\left|\frac{1}{K}\sum_{h=2}^{H} e^{j\Delta\psi_h}\right|
+$$
+
+### 2.8 包絡差アウトライア率
+
+参照・DUT の包絡を最大値で正規化し、包絡勾配（差分）を比較します：
+
+$$
+g[n] = \Delta\left(\frac{A[n]}{\mathrm{scale}}\right)
+$$
+
+参照勾配から閾値を作ります：
+
+$$
+T = P_{95}(|g^{(\mathrm{ref})}|) + \mathrm{median}(|g^{(\mathrm{ref})}|)
+$$
+
+アウトライア率：
+
+$$
+r = \frac{1}{N}\sum_n \mathbf{1}\left(|g^{(\mathrm{dut})}[n]
+- g^{(\mathrm{ref})}[n]| > T\right)
+$$
+
+---
+
+## 3. 実装詳細
+
+実装は `src/microstructure_metrics/metrics/bass.py` の
+`calculate_low_freq_complex_reconstruction()` にあります。`report` の JSON 出力では
+`metrics.bass.*` 配下に入ります（概念としては LFCR）。
+
+### 3.1 パラメータと推奨値
+
+| パラメータ | 型 | デフォルト | 備考 |
+|-----------|---|---------|------|
+| `sample_rate` | int | – | サンプルレート (Hz) |
+| `bands_hz` | (low,high) の列 | ((20,80),(80,200)) | 低域帯域 (Hz) |
+| `filter_order` | int | 4 | Butterworth 次数（ゼロ位相） |
+| `cycle_points` | int | 128 | 1周期の位相グリッド点数 |
+| `envelope_threshold_db` | float | -50.0 | グローバルピークに対する相対閾値 |
+| `harmonic_max_order` | int | 5 | 2..N 倍音（Nyquist 未満） |
+| `fundamental_search_hz` | (float,float) | (30,180) | 基本周波数探索範囲 (Hz) |
+
+### 3.2 疑似コード
+
+実装は 2 章の定義に対応して次の手順で計算します：
+
+1. 帯域ごとに `reference`/`dut` を帯域通過（`sosfiltfilt`）。
+2. 参照の解析信号から位相・包絡を取り、周期を切り出して位相グリッド上で
+   周期波形相関を計算。
+3. 参照 FFT から帯域ごとの基本周波数を推定し、倍音位相コヒーレンスを計算。
+4. 包絡勾配の差分からアウトライア率を計算。
+5. 周期指標は周期包絡重み、コヒーレンス／アウトライア率は帯域 RMS 重みで集約。
+
+### 3.3 エッジケースと特別な処理
+
+- 入力は 1-D かつ同一長である必要があり、空入力は `ValueError`。
+- 帯域は `0 < low < high < Nyquist` を満たさないと `ValueError`。
+- 有効周期が取れない（短すぎる／小さすぎる）場合、その帯域の周期指標は 0.0。
+- 基本周波数推定が無効（\(f_0 \le 0\)）なら、その帯域のコヒーレンスは 0.0。
+
+### 3.4 計算複雑度
+
+\(B\) 帯域、\(N\) サンプルとして：
+- フィルタ：\(\mathcal{O}(B\cdot N)\)
+- ヒルベルト＋FFT：\(\mathcal{O}(B\cdot N\log N)\)
+- 周期補間：\(\mathcal{O}(C\cdot P)\)（\(C\): 使用周期数）
+
+---
+
+## 4. 解釈ガイドライン
+
+### 4.1 主な出力
+
+高いほど良い：
+- `cycle_shape_corr_mean`, `cycle_shape_corr_p05`（理想は 1.0 近傍）
+- `harmonic_phase_coherence`（理想は 1.0 近傍）
+
+低いほど良い：
+- `envelope_diff_outlier_rate`（理想は 0.0 近傍）
+
+帯域別の詳細は `band_metrics` にあり、`fundamental_hz` や使用倍音 `harmonic_orders`
+も確認できます。
+
+### 4.2 実務的な読み方の目安
+
+- **平均が高いが p05 が低い**：概ね良いが、局所的／断続的に周期形状が崩れる
+  （グリッチ、時間変動ワープ、局所クリップ等）可能性。
+- **コヒーレンスが低い**（周期相関はそこそこ）：波形形状は似ているが、
+  倍音位相の整合が崩れている（位相ワープ）可能性。
+- **アウトライア率が高い**：包絡の微小不安定（パンチ感の乱れ）を疑う。
+
+LFCR は低域タイミングに敏感なので、まずパイロット整列が正常であることを確認して
+ください。
+
+---
+
+## 5. 推奨テスト信号
+
+LFCR は、低域に意図的な位相/FM/PM 構造を含む信号で最も有効です。
+
+### 5.1 信号タイプ
+
+- **complex-bass** (`complex-bass`)：30–220 Hz 付近の FM/PM マルチトーン（推奨）
+- **キック＋ベース合成**：実音源に近い複雑な位相／包絡
+- **低域マルチトーン**：位相オフセットを制御した設計信号
+
+### 5.2 例（CLI）
+
+```
+uv run microstructure-metrics generate complex-bass \
+  --duration 10 --sample-rate 48000 --lowcut 30 --highcut 220 \
+  --output ref.wav
+
+uv run microstructure-metrics report ref.wav dut.wav \
+  --output-json report.json --plot
+```
+
+---
+
+## 6. 参考文献
+
+### 理論的背景
+
+- **聴覚科学**：Moore, B. C. J. (2012). *An Introduction to the Psychology of
+  Hearing* (6th ed.). Brill.
+
+### 実装参考資料
+
+- **SciPy 信号処理**: https://docs.scipy.org/doc/scipy/reference/signal.html
+- **NumPy FFT**: https://numpy.org/doc/stable/reference/routines.fft.html
+
+### 関連ドキュメント
+
+- **指標の読み解きガイド**：`docs/jp/metrics-interpretation.md`
+- **信号仕様**：`docs/jp/signal-specifications.md`
+- **測定手順**：`docs/jp/measurement-setup.md`
+
+### ソースコード
+
+- **LFCR（bass）実装**：`src/microstructure_metrics/metrics/bass.py`
+- **信号生成（complex-bass）**：`src/microstructure_metrics/signals/generator.py`
+- **LFCR 可視化**：`src/microstructure_metrics/visualization.py`
+
+---
+
+## 付録：LFCR の一般的な落とし穴
+
+1. **信号が不適切**：純音や定常ノイズでは LFCR が効きにくい。
+2. **整列を省略**：低域の微小ズレで周期比較が大きく崩れる。
+3. **短すぎる信号**：周期数が不足し分位点が不安定になる。
+4. **レベル不一致／クリップ**：周期形状と包絡勾配が不自然に崩れる。


### PR DESCRIPTION
Implements Issue #97 by adding LFCR (Low-Frequency Complex Reconstruction) math/algorithm documentation.

- Add `docs/en/metrics/lfcr.md`
- Add `docs/jp/metrics/lfcr.md`

Closes #97
Part of #92